### PR TITLE
doc: fix assorted typos across documentation

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -226,7 +226,7 @@ todo_include_todos = True
 # is False.
 todo_emit_warnings = True
 
-# Supress "unknown mimetype for ..." warnings
+# Suppress "unknown mimetype for ..." warnings
 suppress_warnings = ['epub.unknown_project_files']
 
 # -- Options for HTML output ---------------------------------------------------

--- a/doc/source/conf_helpers.py
+++ b/doc/source/conf_helpers.py
@@ -16,7 +16,7 @@ def get_current_branch():
         # This means we are operating in a detached head state, will need to
         # parse out the branch that the commit is from.
 
-        # Decode "bytes" type to UTF-8 sting to avoid Python 3 error:
+        # Decode "bytes" type to UTF-8 string to avoid Python 3 error:
         # "TypeError: a bytes-like object is required, not 'str'""
         # https://docs.python.org/3/library/stdtypes.html#bytes.decode
         branches = subprocess.check_output(['git', 'branch']).decode('utf-8').split('\n')

--- a/doc/source/configuration/action/index.rst
+++ b/doc/source/configuration/action/index.rst
@@ -1,4 +1,4 @@
-Depricated Legacy Action-Specific Configuration Statements
+Deprecated Legacy Action-Specific Configuration Statements
 ==========================================================
 
 Statements modify the next action(s) that is/are defined **via legacy syntax**

--- a/doc/source/configuration/cryprov_gcry.rst
+++ b/doc/source/configuration/cryprov_gcry.rst
@@ -53,7 +53,7 @@ to archive both in order to prove integrity.
    downtime, always check carefully when you change the algorithm.
 
 -  **cry.mode** <Algorithm Mode>
-   The encryption mode to be used. Default ist Cipher Block Chaining
+   The encryption mode to be used. Default is Cipher Block Chaining
    (CBC). Note that not all encryption modes can be used together with
    all algorithms.
    Currently, the following modes are supported:

--- a/doc/source/configuration/lookup_tables.rst
+++ b/doc/source/configuration/lookup_tables.rst
@@ -140,9 +140,9 @@ A ``lookup`` call looks like:
 
 ::
 
-   set $.bu = lookup("host_bu", $hostname);
-   
-   if ($.bu == "unknown") then {
+   set $.business_unit = lookup("host_business_unit", $hostname);
+
+   if ($.business_unit == "unknown") then {
        ....
    }
 

--- a/doc/source/configuration/modules/idx_stringgen.rst
+++ b/doc/source/configuration/modules/idx_stringgen.rst
@@ -18,7 +18,7 @@ to stay stable. So it may be necessary to modify string generator
 modules if the interface changes. Obviously, we will not do that without
 good reason, but it may happen.
 
-Rsyslog comes with a set of core, build-in string generators, which are
+Rsyslog comes with a set of core, built-in string generators, which are
 used to provide those default templates that we consider to be
 time-critical:
 
@@ -37,7 +37,7 @@ provided. If you can not do this yourself, you may want to contact
 string generators at a very low price.
 
 Note that string generator modules can be dynamically loaded. However,
-the default ones provided are so important that they are build right
+the default ones provided are so important that they are built right
 into the executable. But this does not need to be done that way (and it
 is straightforward to do it dynamic).
 

--- a/doc/source/configuration/modules/imdtls.rst
+++ b/doc/source/configuration/modules/imdtls.rst
@@ -192,7 +192,7 @@ tls.tlscfgcmd
    "string", "none", "no", "none"
 
 Used to pass additional OpenSSL configuration commands. This can be used to fine-tune the OpenSSL
-settings by passing configuration commands to the openssl libray.
+settings by passing configuration commands to the openssl library.
 OpenSSL Version 1.0.2 or higher is required for this feature.
 A list of possible commands and their valid values can be found in the documentation:
 https://docs.openssl.org/1.0.2/man3/SSL_CONF_cmd/

--- a/doc/source/configuration/modules/imklog.rst
+++ b/doc/source/configuration/modules/imklog.rst
@@ -166,7 +166,7 @@ RatelimitBurst
 .. versionadded:: 8.35.0
 
 Specifies the rate-limiting burst in number of messages.  Set it high to
-preserve all bootup messages.
+preserve all boot-up messages.
 
 
 Caveats/Known Bugs

--- a/doc/source/configuration/modules/imkmsg.rst
+++ b/doc/source/configuration/modules/imkmsg.rst
@@ -66,7 +66,7 @@ been told cases where this is in the magnitude of days. Just think about
 desktops which are in hibernate during the night, missing several hours
 each day. So this is a real-world problem.
 
-To work around this, we usually do **not** use the kernel timstamp when
+To work around this, we usually do **not** use the kernel timestamp when
 we calculate the message time. Instead, we use wallclock time (obtained
 from the respective linux timer) of the instant when imkmsg reads the
 message from the kernel log. As message creation and imkmsg reading it
@@ -75,7 +75,7 @@ is usually in very close time proximity, this approach works very well.
 **However**, this is not helpful for e.g. early boot messages. These
 were potentially generated some seconds to a minute or two before rsyslog
 startup. To provide a proper meaning of time for these events, we use
-the kernel timstamp instead of wallclock time during rsyslog startup.
+the kernel timestamp instead of wallclock time during rsyslog startup.
 This is most probably correct, because it is extremely unlikely (close
 to impossible) that the system entered a low-power state before rsyslog
 startup.

--- a/doc/source/configuration/modules/imrelp.rst
+++ b/doc/source/configuration/modules/imrelp.rst
@@ -378,8 +378,8 @@ tls.tlscfgcmd
 
 .. versionadded:: 8.2001.0
 
-The setting can be used if tls.tlslib is set to "openssl" to pass configuration commands to 
-the openssl libray.
+The setting can be used if tls.tlslib is set to "openssl" to pass configuration commands to
+the openssl library.
 OpenSSL Version 1.0.2 or higher is required for this feature.
 A list of possible commands and their valid values can be found in the documentation:
 https://docs.openssl.org/1.0.2/man3/SSL_CONF_cmd/
@@ -419,8 +419,8 @@ KeepAlive
 
    "binary", "off", "no", "none"
 
-Enable or disable keep-alive packets at the TCP socket layer. By 
-default keep-alives are disabled.
+Enable or disable keep-alive packets at the TCP socket layer. By
+default keep-alive is disabled.
 
 
 KeepAlive.Probes
@@ -435,8 +435,8 @@ KeepAlive.Probes
 
 The number of keep-alive probes to send before considering the
 connection dead and notifying the application layer. The default, 0,
-means that the operating system defaults are used. This only has an 
-effect if keep-alives are enabled. The functionality may not be
+means that the operating system defaults are used. This only has an
+effect if keep-alive is enabled. The functionality may not be
 available on all platforms.
 
 

--- a/doc/source/configuration/modules/mmanon.rst
+++ b/doc/source/configuration/modules/mmanon.rst
@@ -30,7 +30,7 @@ where each of the octets has a value between 0 and 255, inclusively.
 An IPv6 is defined by being between zero and eight hex values between 0
 and ffff. These are separated by ':'. Leading zeros in blocks can be omitted
 and blocks full of zeros can be abbreviated by using '::'. However, this
-can ony happen once in an IP address.
+can only happen once in an IP address.
 
 An IPv6 address with embedded IPv4 is an IPv6 address where the last two blocks
 have been replaced by an IPv4 address. (see also: RFC4291, 2.2.3) 

--- a/doc/source/configuration/modules/mmpstrucdata.rst
+++ b/doc/source/configuration/modules/mmpstrucdata.rst
@@ -77,7 +77,7 @@ in user variables before anonymization).
 
 Take this example message (inspired by RFC5424 sample;)):
 
-``<34>1 2003-10-11T22:14:15.003Z mymachine.example.com su - ID47 [exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"][id@2 test="tast"] BOM'su root' failed for lonvick on /dev/pts/8``
+``<34>1 2003-10-11T22:14:15.003Z mymachine.example.com su - ID47 [exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"][id@2 test="test"] BOM'su root' failed for lonvick on /dev/pts/8``
 
 We apply this configuration:
 
@@ -93,7 +93,7 @@ We apply this configuration:
 
 This will output:
 
-``ALL: { "rfc5424-sd": { "examplesdid@32473": { "iut": "3", "eventsource": "Application", "eventid": "1011" }, "id@2": { "test": "tast" } } } SD: { "examplesdid@32473": { "iut": "3", "eventsource": "Application", "eventid": "1011" }, "id@2": { "test": "tast" } } IUT:3 RAWMSG: <34>1 2003-10-11T22:14:15.003Z mymachine.example.com su - ID47 [exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"][id@2 test="tast"] BOM'su root' failed for lonvick on /dev/pts/8``
+``ALL: { "rfc5424-sd": { "examplesdid@32473": { "iut": "3", "eventsource": "Application", "eventid": "1011" }, "id@2": { "test": "test" } } } SD: { "examplesdid@32473": { "iut": "3", "eventsource": "Application", "eventid": "1011" }, "id@2": { "test": "test" } } IUT:3 RAWMSG: <34>1 2003-10-11T22:14:15.003Z mymachine.example.com su - ID47 [exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"][id@2 test="test"] BOM'su root' failed for lonvick on /dev/pts/8``
 
 As you can seem, you can address each of the individual items. Note that
 the case of the RFC5424 parameter names has been converted to lower

--- a/doc/source/configuration/modules/omdtls.rst
+++ b/doc/source/configuration/modules/omdtls.rst
@@ -160,7 +160,7 @@ tls.tlscfgcmd
    "string", "none", "no", "none"
 
 Used to pass additional OpenSSL configuration commands. This can be used to fine-tune the OpenSSL
-settings by passing configuration commands to the openssl libray.
+settings by passing configuration commands to the openssl library.
 OpenSSL Version 1.0.2 or higher is required for this feature.
 A list of possible commands and their valid values can be found in the documentation:
 https://docs.openssl.org/1.0.2/man3/SSL_CONF_cmd/

--- a/doc/source/configuration/modules/omhiredis.rst
+++ b/doc/source/configuration/modules/omhiredis.rst
@@ -65,7 +65,7 @@ ServerPassword
 
 Password to support authenticated redis database server to push messages
 across networks and datacenters. Parameter is optional if not provided
-AUTH command wont be sent to the server.
+AUTH command won't be sent to the server.
 
 
 Mode

--- a/doc/source/configuration/modules/omhttp.rst
+++ b/doc/source/configuration/modules/omhttp.rst
@@ -659,15 +659,15 @@ Additionally, the following statistics can also be configured for a specific act
 
 - **requests.status.0xx** - Number of failed requests. 0xx errors indicate request never reached destination.
 
-- **requests.status.1xx** - Number of HTTP requests returing 1xx status codes
+- **requests.status.1xx** - Number of HTTP requests returning 1xx status codes
 
-- **requests.status.2xx** - Number of HTTP requests returing 2xx status codes
+- **requests.status.2xx** - Number of HTTP requests returning 2xx status codes
 
-- **requests.status.3xx** - Number of HTTP requests returing 3xx status codes
+- **requests.status.3xx** - Number of HTTP requests returning 3xx status codes
 
-- **requests.status.4xx** - Number of HTTP requests returing 4xx status codes
+- **requests.status.4xx** - Number of HTTP requests returning 4xx status codes
 
-- **requests.status.5xx** - Number of HTTP requests returing 5xx status codes
+- **requests.status.5xx** - Number of HTTP requests returning 5xx status codes
 
 - **requests.bytes** - Total number of bytes sent - derived from CURLINFO_REQUEST_SIZE.
 

--- a/doc/source/configuration/modules/omkafka.rst
+++ b/doc/source/configuration/modules/omkafka.rst
@@ -204,8 +204,8 @@ accumulate all action instances. The statistic origin is named "omafka" with fol
 - **int_latency_avg_usec** - internal librdkafka producer queue latency in microseconds averaged other
   all brokers. This is also part of window statistics and average excludes brokers with zero internal latency.
 
-Note that three window statics counters are not safe with multiple clients. When statistics callback is
-enabled, for example, by using statics.callback.ms=60000, omkafka will generate an internal log message every
+Note that three window statistics counters are not safe with multiple clients. When statistics callback is
+enabled, for example, by using statistics.interval.ms=60000, omkafka will generate an internal log message every
 minute for the corresponding omkafka action:
 
 .. code-block:: none

--- a/doc/source/configuration/modules/ommongodb.rst
+++ b/doc/source/configuration/modules/ommongodb.rst
@@ -35,7 +35,7 @@ UriStr
 
    "word", "none", "no", "none"
 
-MongoDB connexion string, as defined by the MongoDB String URI Format (See: https://docs.mongodb.com/manual/reference/connection-string/). If uristr is defined, following directives will be ignored: server, serverport, uid, pwd.
+MongoDB connection string, as defined by the MongoDB String URI Format (See: https://docs.mongodb.com/manual/reference/connection-string/). If uristr is defined, following directives will be ignored: server, serverport, uid, pwd.
 
 
 SSL_Cert

--- a/doc/source/configuration/modules/omrabbitmq.rst
+++ b/doc/source/configuration/modules/omrabbitmq.rst
@@ -215,7 +215,7 @@ delivery\_mode
   :widths: auto
   :class: parameter-table
 
-  "string", "no", "TRANSIENT\|PERSISTANT", "TRANSIENT"
+  "string", "no", "TRANSIENT\|PERSISTENT", "TRANSIENT"
 
 persistence of the message in the broker
 

--- a/doc/source/configuration/modules/omrelp.rst
+++ b/doc/source/configuration/modules/omrelp.rst
@@ -225,7 +225,7 @@ Note: this parameter is mandatory depending on the value of
 
 Peer Places access restrictions on this forwarder. Only peers which
 have been listed in this parameter may be connected to. This guards
-against rouge servers and man-in-the-middle attacks. The validation
+against rogue servers and man-in-the-middle attacks. The validation
 bases on the certificate the remote peer presents.
 
 This contains either remote system names or fingerprints, depending
@@ -386,8 +386,8 @@ tls.tlscfgcmd
 
 .. versionadded:: 8.2001.0
 
-The setting can be used if tls.tlslib is set to "openssl" to pass configuration commands to 
-the openssl libray.
+The setting can be used if tls.tlslib is set to "openssl" to pass configuration commands to
+the openssl library.
 OpenSSL Version 1.0.2 or higher is required for this feature.
 A list of possible commands and their valid values can be found in the documentation:
 https://docs.openssl.org/1.0.2/man3/SSL_CONF_cmd/

--- a/doc/source/configuration/modules/omudpspoof.rst
+++ b/doc/source/configuration/modules/omudpspoof.rst
@@ -93,7 +93,7 @@ This is the name of the template that contains a numerical IP
 address that is to be used as the source system IP address. While it
 may often be a constant value, it can be generated as usual via the
 property replacer, as long as it is a valid IPv4 address. If not
-specified, the build-in default template
+specified, the built-in default template
 RSYSLOG\_omudpspoofDfltSourceTpl is used. This template is defined as
 follows:
 $template RSYSLOG\_omudpspoofDfltSourceTpl,"%fromhost-ip%"

--- a/doc/source/configuration/property_replacer.rst
+++ b/doc/source/configuration/property_replacer.rst
@@ -278,13 +278,13 @@ options are defined:
   returns the ordinal for the given day, e.g. it is 2 for January, 2nd
 
 **date-iso-week** and **date-iso-week-year**
-  return the ISO week number adn week-numbering year, which should be used together. See `ISO week date <https://en.wikipedia.org/wiki/ISO_week_date>`_ for more details
+  return the ISO week number and week-numbering year, which should be used together. See `ISO week date <https://en.wikipedia.org/wiki/ISO_week_date>`_ for more details
 
 **date-week**
   returns the week number
 
 **date-wday**
-  just the weekday number of the timstamp. This is a single digit,
+  just the weekday number of the timestamp. This is a single digit,
   with 0=Sunday, 1=Monday, ..., 6=Saturday.
 
 **date-wdayname**

--- a/doc/source/configuration/rsyslog-example.conf
+++ b/doc/source/configuration/rsyslog-example.conf
@@ -82,7 +82,7 @@ $template MyTemplateName,"\7Text %property% some more text\n",
 # If you need to obtain the first 2 characters of the
 # message text, you can use this syntax: 
 "%msg:1:2%".
-# If you do not whish to specify from and to, but you want to
+# If you do not wish to specify from and to, but you want to
 # specify options, you still need to include the colons. 
 
 # For example, to convert the full message text to lower case only, use 
@@ -102,7 +102,7 @@ $template TraditionalFormat,"%timegenerated% %HOSTNAME% %syslogtag%%msg:::drop-l
 $template precise,"%syslogpriority%,%syslogfacility%,%timegenerated::fulltime%,%HOSTNAME%,%syslogtag%,%msg%\n"
 
 # A template that resembles RFC 3164 on-the-wire format:
-# (yes, there is NO space betwen syslogtag and msg! that's important!)
+# (yes, there is NO space between syslogtag and msg! that's important!)
 $template RFC3164fmt,"<%PRI%>%TIMESTAMP% %HOSTNAME% %syslogtag%%msg%"
 
 # a template resembling traditional wallmessage format:

--- a/doc/source/configuration/ruleset/rsconf1_rulesetparser.rst
+++ b/doc/source/configuration/ruleset/rsconf1_rulesetparser.rst
@@ -15,7 +15,7 @@ This directive permits to specify which `message
 parsers <../../concepts/messageparser.html>`_ should be used for the ruleset in
 question. It no ruleset is explicitly specified, the default ruleset is
 used. Message parsers are contained in (loadable) parser modules with
-the most common cases (RFC3164 and RFC5424) being build-in into
+the most common cases (RFC3164 and RFC5424) being built into
 rsyslogd.
 
 When this directive is specified the first time for a ruleset, it will

--- a/doc/source/development/dev_oplugins.rst
+++ b/doc/source/development/dev_oplugins.rst
@@ -14,7 +14,7 @@ Getting Started and Samples
 ---------------------------
 
 The best to get started with rsyslog plugin development is by looking at
-existing plugins. All that start with "om" are **o**\ utput
+existing plugins. All that start with "om" are **o**\ output
 **m**\ odules. That means they are primarily thought of being message
 sinks. In theory, however, output plugins may aggregate other
 functionality, too. Nobody has taken this route so far so if you would

--- a/doc/source/development/dev_queue.rst
+++ b/doc/source/development/dev_queue.rst
@@ -234,7 +234,7 @@ Queue Destruction
 ~~~~~~~~~~~~~~~~~
 
 Now let's consider **the case of destruction of the primary
-queue.**\ During destruction, our focus is on loosing as few messages as
+queue.**\ During destruction, our focus is on losing as few messages as
 possible. If the queue is not DA-enabled, there is nothing but the
 configured timeouts to handle that situation. However, with a DA-enabled
 queue there are more options.

--- a/doc/source/historical/multi_ruleset_legacy_format_samples.rst
+++ b/doc/source/historical/multi_ruleset_legacy_format_samples.rst
@@ -147,7 +147,7 @@ only. But this time we set up three syslog/tcp listeners, each one
 listening to a different port (in this example 10514, 10515, and 10516).
 Logs received from these receivers shall go into different files. Also,
 logs received from 10516 (and only from that port!) with "mail.\*"
-priority, shall be written into a specif file and **not** be written to
+priority, shall be written into a specific file and **not** be written to
 10516's general log file.
 
 This is the config:

--- a/doc/source/historical/php_syslog_ng.rst
+++ b/doc/source/historical/php_syslog_ng.rst
@@ -76,7 +76,7 @@ outdated, `let me know <mailto:rgerhards@adiscon.com>`_ so that I can
 fix it.
 
 Once this schema is created, we simply instruct rsyslogd to store
-received data in it. I wont go into too much detail here. If you are
+received data in it. I won't go into too much detail here. If you are
 interested in some more details, you might find my paper "`Writing
 syslog messages to MySQL <rsyslog_mysql.html>`_\ " worth reading. For
 this article, we simply modify `rsyslog.conf <rsyslog_conf.html>`_\ so

--- a/doc/source/includes/substitution_definitions.inc.rst
+++ b/doc/source/includes/substitution_definitions.inc.rst
@@ -18,7 +18,7 @@
 .. _RsyslogDockerHub: https://hub.docker.com/u/rsyslog/
 
 .. |GitHubDockerProject| replace:: rsyslog docker definitions
-.. _GitHubDockerProject: https://github.com/rsyslog/rsyslog/packging/docker
+.. _GitHubDockerProject: https://github.com/rsyslog/rsyslog/packaging/docker
 
 .. |DockerApplianceAlpineDockerHubRepo| replace:: Alpine rsyslog appliance Docker Hub repo
 .. _DockerApplianceAlpineDockerHubRepo: https://hub.docker.com/r/rsyslog/syslog_appliance_alpine/

--- a/doc/source/proposals/version_naming.rst
+++ b/doc/source/proposals/version_naming.rst
@@ -64,7 +64,7 @@ if someone has asked for the feature). So we do not like to wait for the
 original focus feature to be ready (what could take maybe three more
 weeks). As a result, we release the new features. But that version will
 also include partial code of the focus feature. Typically this doesn't
-hurt as long as noone tries to use it (what of course would miserably
+hurt as long as no one tries to use it (what of course would miserably
 fail). But still, part of the new code is already in it. When we release
 such a "minor-feature enhanced" but "focus-feature not yet completed"
 version, we need a way to flag it. In current thinking, that is using a

--- a/doc/source/rainerscript/functions/mo-http_request.rst
+++ b/doc/source/rainerscript/functions/mo-http_request.rst
@@ -11,7 +11,7 @@ Performs an HTTP request to target and returns the result of said request.
 
 .. note::
 
-   this function is very slow and therefore we suggest using it only seldomly
+   this function is very slow and therefore we suggest using it only seldom
    to insure adequate performance.
 
 

--- a/doc/source/rainerscript/functions/mo-http_request.rst
+++ b/doc/source/rainerscript/functions/mo-http_request.rst
@@ -12,7 +12,7 @@ Performs an HTTP request to target and returns the result of said request.
 .. note::
 
    this function is very slow and therefore we suggest using it only seldom
-   to insure adequate performance.
+   to ensure adequate performance.
 
 
 Example

--- a/doc/source/rainerscript/functions/rs-lookup.rst
+++ b/doc/source/rainerscript/functions/rs-lookup.rst
@@ -28,6 +28,6 @@ the corresponding value is returned.
 .. code-block:: none
 
    lookup_table(name="host_bu" file="/var/lib/host_billing_unit_mapping.json")
-   set $.bu = lookup("host_bu", $hostname);
+   set $.business_unit = lookup("host_business_unit", $hostname);
 
 

--- a/doc/source/rainerscript/functions/rs-lookup.rst
+++ b/doc/source/rainerscript/functions/rs-lookup.rst
@@ -25,9 +25,10 @@ Example
 In the following example the hostname is looked up in the given table and
 the corresponding value is returned.
 
-.. code-block:: none
+   .. code-block:: none
 
    lookup_table(name="host_bu" file="/var/lib/host_billing_unit_mapping.json")
-   set $.business_unit = lookup("host_business_unit", $hostname);
+   set $.bu = lookup("host_bu", $hostname);
+   set $.business_unit = lookup("host_bu", $hostname);
 
 

--- a/doc/source/rainerscript/queue_parameters.rst
+++ b/doc/source/rainerscript/queue_parameters.rst
@@ -471,7 +471,7 @@ With all progress blocked (unable to deliver a message):
 * all delayable inputs (tcp, relp, imfile, imjournal, etc) will block
   indefinitely (assuming queue.lightdelaymark and queue.fulldelaymark
   are set sensible, which they are by default).
-* imudp will be loosing messages because the OS will be dropping them
+* imudp will be losing messages because the OS will be dropping them
 * messages arriving via UDP or imuxsock that do make it to rsyslog,
   and that are a severity high enough to not be filtered by
   discardseverity, will block for 2 seconds trying to put the message in

--- a/doc/source/reference/parameters/omfile-sync.rst
+++ b/doc/source/reference/parameters/omfile-sync.rst
@@ -33,7 +33,7 @@ directory it resides after processing each batch. There currently
 is no way to sync only after each n-th batch.
 
 Enabling sync causes a severe performance hit. Actually,
-it slows omfile so much down, that the probability of loosing messages
+it slows omfile so much down, that the probability of losing messages
 **increases**. In short,
 you should enable syncing only if you know exactly what you do, and
 fully understand how the rest of the engine works, and have tuned

--- a/doc/source/troubleshooting/selinux.rst
+++ b/doc/source/troubleshooting/selinux.rst
@@ -15,7 +15,7 @@ do the following:
 If it now succeeds, you know that you have a SELinux policy issue.
 The solution here is **not** to keep SELinux disabled. Instead do:
 
-* reenable SELinux (set back to previous state, whatever that was)
+* re-enable SELinux (set back to previous state, whatever that was)
 * add proper SELinux policies for what you want to do with rsyslog
 
 With SELinux running, restart rsyslog

--- a/doc/source/tutorials/database.rst
+++ b/doc/source/tutorials/database.rst
@@ -130,7 +130,7 @@ Does that mean you need to create database schema yourself and also must
 fully understand rsyslogd's properties? No, that's not needed. Because
 we anticipated that folks are probably more interested in getting things
 going instead of designing them from scratch. So we have provided a
-default schema as well as build-in support for it. This schema also
+default schema as well as built-in support for it. This schema also
 offers an additional benefit: rsyslog is part of
 `Adiscon <http://www.adiscon.com/en/>`_'s `MonitorWare product
 line <http://www.monitorware.com/en/>`_ (which includes open source and
@@ -152,7 +152,7 @@ table was successfully created.
 
 It is important to note that the correct database encoding must be used
 so that the database will accept strings independent of the string
-encoding. This is an important part because it can not be guarantied
+encoding. This is an important part because it can not be guaranteed
 that all syslog messages will have a defined character encoding. This is
 especially true if the rsyslog-Server will collect messages from
 different clients and different products.

--- a/doc/source/whitepapers/reliable_logging.rst
+++ b/doc/source/whitepapers/reliable_logging.rst
@@ -50,7 +50,7 @@ will get dropped at the network layer if the remote system is unresponsive.
 You have lots of options.
 
 If you are really concerned with reliability, I should point out that using
-TCP does not eliminate the possibility of loosing logs when a remote system
+TCP does not eliminate the possibility of losing logs when a remote system
 goes down. When you send a message via TCP, the sender considers it sent
 when it's handed to the OS to send it. The OS has a window of how much data
 it allows to be outstanding (sent without acknowledgement from the remote
@@ -66,7 +66,7 @@ the OS after rsyslog tells the OS to write the logs) as potential data loss
 points. Those failures will only trigger if the system crashes or rsyslog
 is shutdown (and yes, there are ways to address these as well)
 
-The reason why nothing today operates without the possibility of loosing
+The reason why nothing today operates without the possibility of losing
 log messages is that making the logs completely reliable absolutely kills
 performance. With buffering, rsyslog can handle 400,000 logs/sec on a
 low-mid range machine. With utterly reliable logs and spinning disks, this

--- a/doc/source/whitepapers/syslog_parsing.rst
+++ b/doc/source/whitepapers/syslog_parsing.rst
@@ -83,7 +83,7 @@ but does not precisely specify anything.
 
 After all of this bashing, I now have to admit that RFC3164 has some
 format recommendations laid out in section 4. The format described has
-quite some value in it and implementors recently try to follow it. This
+quite some value in it and implementers recently try to follow it. This
 format is usually meant when someone tells you that a software is
 "RFC3164 compliant" or expects "RFC3164 compliant messages". I also have
 to admit that rsyslog also uses this format and, in the sense outlined

--- a/doc/source/whitepapers/syslog_protocol.rst
+++ b/doc/source/whitepapers/syslog_protocol.rst
@@ -64,7 +64,7 @@ This lists what has been found during implementation:
    no way to find out what it is. In order to make the syslogd do
    anything useful, I have now simply taken the message as is and
    stuffed it into the MSG part. Please note that I think this will be a
-   route that other implementors would take, too.
+   route that other implementers would take, too.
 -  A minimal parser is easy to implement. It took me roughly 2 hours to
    add it to rsyslogd. This includes the time for restructuring the code
    to be able to parse both legacy syslog as well as syslog-protocol.
@@ -75,7 +75,7 @@ This lists what has been found during implementation:
       errors caught. For my needs with this syslogd, that level of
       structured data processing is probably sufficient. I do not want
       to parse/validate it in all cases. This is also a performance
-      issue. I think other implementors could have the same view. As
+      issue. I think other implementers could have the same view. As
       such, we should not make validation a requirement.
    -  MSG is not further processed (e.g. Unicode not being validated)
    -  the other header fields are also extracted, but no validation is
@@ -207,7 +207,7 @@ be discussed ;)
    (see section 155.9 of
    `https://www.unicode.org/versions/Unicode4.0.0/ch15.pdf <https://www.unicode.org/versions/Unicode4.0.0/ch15.pdf>`_)
 -  Requirements to drop messages should be reconsidered. I guess I would
-   not be the only implementor ignoring them.
+   not be the only implementer ignoring them.
 -  Logging requirements should be reconsidered and probably be removed.
 -  It would be advisable to specify "-" for APP-NAME is the name is not
    known to the sender.


### PR DESCRIPTION
## Summary
- correct spelling mistakes and phrasing in multiple docs
- clarify lookup table examples by renaming variables

## Testing
- `./devtools/format-code.sh`
- `make -C doc html`

------
https://chatgpt.com/codex/tasks/task_e_68af265756a88330a403808d00501b4e