### PR TITLE
mmsequence: split parameter docs into reference pages

### DIFF
--- a/doc/source/configuration/modules/mmsequence.rst
+++ b/doc/source/configuration/modules/mmsequence.rst
@@ -28,51 +28,56 @@ random numbers in a given range.
 This module is implemented via the output module interface, so it is
 called just as an action. The number generated is stored in a variable.
 
- 
+Configuration Parameters
+========================
 
-**Action Parameters**:
+.. note::
 
-Note: parameter names are case-insensitive.
+   Parameter names are case-insensitive; camelCase is recommended for readability.
 
--  **mode** "random" or "instance" or "key"
+Module Parameters
+-----------------
 
-   Specifies mode of the action. In "random" mode, the module generates
-   uniformly distributed integer numbers in a range defined by "from"
-   and "to".
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
 
-   In "instance" mode, which is default, the action produces a counter
-   in range [from, to). This counter is specific to this action
-   instance.
+   * - Parameter
+     - Summary
+   * - :ref:`param-mmsequence-mode`
+     - .. include:: ../../reference/parameters/mmsequence-mode.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-mmsequence-from`
+     - .. include:: ../../reference/parameters/mmsequence-from.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-mmsequence-to`
+     - .. include:: ../../reference/parameters/mmsequence-to.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-mmsequence-step`
+     - .. include:: ../../reference/parameters/mmsequence-step.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-mmsequence-key`
+     - .. include:: ../../reference/parameters/mmsequence-key.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-mmsequence-var`
+     - .. include:: ../../reference/parameters/mmsequence-var.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
 
-   In "key" mode, the counter can be shared between multiple instances.
-   This counter is identified by a name, which is defined with "key"
-   parameter.
+.. toctree::
+   :hidden:
 
--  **from** [non-negative integer], default "0"
-
-   Starting value for counters and lower margin for random generator.
-
--  **to** [positive integer], default "INT\_MAX"
-
-   Upper margin for all sequences. Note that this margin is not
-   inclusive. When next value for a counter is equal or greater than
-   this parameter, the counter resets to the starting value.
-
--  **step** [non-negative integer], default "1"
-
-   Increment for counters. If step is "0", it can be used to fetch
-   current value without modification. The latter not applies to
-   "random" mode. This is useful in "key" mode or to get constant values
-   in "instance" mode.
-
--  **key** [word], default ""
-
-   Name of the global counter which is used in this action.
-
--  **var** [word], default "$!mmsequence"
-
-   Name of the variable where the number will be stored. Should start
-   with "$".
+   ../../reference/parameters/mmsequence-mode
+   ../../reference/parameters/mmsequence-from
+   ../../reference/parameters/mmsequence-to
+   ../../reference/parameters/mmsequence-step
+   ../../reference/parameters/mmsequence-key
+   ../../reference/parameters/mmsequence-var
 
 **Sample**:
 

--- a/doc/source/reference/parameters/mmsequence-from.rst
+++ b/doc/source/reference/parameters/mmsequence-from.rst
@@ -1,0 +1,42 @@
+.. _param-mmsequence-from:
+.. _mmsequence.parameter.module.from:
+
+from
+====
+
+.. index::
+   single: mmsequence; from
+   single: from
+
+.. summary-start
+
+Sets the starting value for counters and the lower margin for random numbers.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/mmsequence`.
+
+:Name: from
+:Scope: module
+:Type: integer
+:Default: module=0
+:Required?: no
+:Introduced: 7.5.6
+
+Description
+-----------
+Starting value for counters and lower margin for random generator.
+
+Module usage
+------------
+.. _param-mmsequence-module-from:
+.. _mmsequence.parameter.module.from-usage:
+
+.. code-block:: rsyslog
+
+   action(type="mmsequence" from="0")
+
+See also
+--------
+See also :doc:`../../configuration/modules/mmsequence`.
+

--- a/doc/source/reference/parameters/mmsequence-key.rst
+++ b/doc/source/reference/parameters/mmsequence-key.rst
@@ -1,0 +1,42 @@
+.. _param-mmsequence-key:
+.. _mmsequence.parameter.module.key:
+
+key
+===
+
+.. index::
+   single: mmsequence; key
+   single: key
+
+.. summary-start
+
+Names the global counter shared between multiple action instances.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/mmsequence`.
+
+:Name: key
+:Scope: module
+:Type: string
+:Default: module=
+:Required?: no
+:Introduced: 7.5.6
+
+Description
+-----------
+Name of the global counter which is used in this action.
+
+Module usage
+------------
+.. _param-mmsequence-module-key:
+.. _mmsequence.parameter.module.key-usage:
+
+.. code-block:: rsyslog
+
+   action(type="mmsequence" key="globalCounter")
+
+See also
+--------
+See also :doc:`../../configuration/modules/mmsequence`.
+

--- a/doc/source/reference/parameters/mmsequence-mode.rst
+++ b/doc/source/reference/parameters/mmsequence-mode.rst
@@ -1,0 +1,46 @@
+.. _param-mmsequence-mode:
+.. _mmsequence.parameter.module.mode:
+
+mode
+====
+
+.. index::
+   single: mmsequence; mode
+   single: mode
+
+.. summary-start
+
+Selects the sequence generation mode: random numbers, per-action counter, or shared counter.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/mmsequence`.
+
+:Name: mode
+:Scope: module
+:Type: string
+:Default: module=instance
+:Required?: no
+:Introduced: 7.5.6
+
+Description
+-----------
+Specifies mode of the action. In ``random`` mode, the module generates uniformly distributed integer numbers in a range defined by ``from`` and ``to``.
+
+In ``instance`` mode, which is default, the action produces a counter in range [``from``, ``to``). This counter is specific to this action instance.
+
+In ``key`` mode, the counter can be shared between multiple instances. This counter is identified by a name, which is defined with ``key`` parameter.
+
+Module usage
+------------
+.. _param-mmsequence-module-mode:
+.. _mmsequence.parameter.module.mode-usage:
+
+.. code-block:: rsyslog
+
+   action(type="mmsequence" mode="instance")
+
+See also
+--------
+See also :doc:`../../configuration/modules/mmsequence`.
+

--- a/doc/source/reference/parameters/mmsequence-step.rst
+++ b/doc/source/reference/parameters/mmsequence-step.rst
@@ -1,0 +1,42 @@
+.. _param-mmsequence-step:
+.. _mmsequence.parameter.module.step:
+
+step
+====
+
+.. index::
+   single: mmsequence; step
+   single: step
+
+.. summary-start
+
+Specifies the increment for counters; ``0`` fetches the current value without changing it.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/mmsequence`.
+
+:Name: step
+:Scope: module
+:Type: integer
+:Default: module=1
+:Required?: no
+:Introduced: 7.5.6
+
+Description
+-----------
+Increment for counters. If step is ``0``, it can be used to fetch current value without modification. The latter does not apply to ``random`` mode. This is useful in ``key`` mode or to get constant values in ``instance`` mode.
+
+Module usage
+------------
+.. _param-mmsequence-module-step:
+.. _mmsequence.parameter.module.step-usage:
+
+.. code-block:: rsyslog
+
+   action(type="mmsequence" step="1")
+
+See also
+--------
+See also :doc:`../../configuration/modules/mmsequence`.
+

--- a/doc/source/reference/parameters/mmsequence-to.rst
+++ b/doc/source/reference/parameters/mmsequence-to.rst
@@ -1,0 +1,42 @@
+.. _param-mmsequence-to:
+.. _mmsequence.parameter.module.to:
+
+to
+==
+
+.. index::
+   single: mmsequence; to
+   single: to
+
+.. summary-start
+
+Sets the upper margin for sequences; the counter resets when reaching or exceeding this value.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/mmsequence`.
+
+:Name: to
+:Scope: module
+:Type: integer
+:Default: module=INT_MAX
+:Required?: no
+:Introduced: 7.5.6
+
+Description
+-----------
+Upper margin for all sequences. Note that this margin is not inclusive. When next value for a counter is equal or greater than this parameter, the counter resets to the starting value.
+
+Module usage
+------------
+.. _param-mmsequence-module-to:
+.. _mmsequence.parameter.module.to-usage:
+
+.. code-block:: rsyslog
+
+   action(type="mmsequence" to="100")
+
+See also
+--------
+See also :doc:`../../configuration/modules/mmsequence`.
+

--- a/doc/source/reference/parameters/mmsequence-var.rst
+++ b/doc/source/reference/parameters/mmsequence-var.rst
@@ -1,0 +1,42 @@
+.. _param-mmsequence-var:
+.. _mmsequence.parameter.module.var:
+
+var
+===
+
+.. index::
+   single: mmsequence; var
+   single: var
+
+.. summary-start
+
+Specifies the variable where the generated number will be stored.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/mmsequence`.
+
+:Name: var
+:Scope: module
+:Type: string
+:Default: module=$!mmsequence
+:Required?: no
+:Introduced: 7.5.6
+
+Description
+-----------
+Name of the variable where the number will be stored. Should start with ``$``.
+
+Module usage
+------------
+.. _param-mmsequence-module-var:
+.. _mmsequence.parameter.module.var-usage:
+
+.. code-block:: rsyslog
+
+   action(type="mmsequence" var="$!seq")
+
+See also
+--------
+See also :doc:`../../configuration/modules/mmsequence`.
+


### PR DESCRIPTION
## Summary
- split mmsequence action parameters into dedicated reference pages
- replace inline parameter docs with summary list-table and includes
- add hidden toctree for new parameter pages and fix anchors

## Testing
- `make html`
- `devtools/format-code.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bffb6bfb48833095d4f017b7d973cf