### PR TITLE
mmutf8fix: split parameter docs into reference pages

### DIFF
--- a/doc/source/configuration/modules/mmutf8fix.rst
+++ b/doc/source/configuration/modules/mmutf8fix.rst
@@ -45,39 +45,35 @@ their incoming traffic, bind them to specific
 `ruleset <multi_ruleset.html>`_ and call mmutf8fix as first action in
 this ruleset.
 
-**Module Configuration Parameters**:
+Configuration Parameters
+========================
 
-Note: parameter names are case-insensitive.
+.. note::
 
-Currently none.
+   Parameter names are case-insensitive; camelCase is recommended for readability.
 
- 
+Module Parameters
+-----------------
 
-**Action Configuration Parameters**:
+This module has no module parameters.
 
-Note: parameter names are case-insensitive.
+Action Parameters
+-----------------
 
--  **mode** - **utf-8**/controlcharacters
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
 
-   This sets the basic detection mode.
-   In **utf-8** mode (the default), proper UTF-8 encoding is checked and
-   bytes which are not proper UTF-8 sequences are acted on. If a proper
-   multi-byte start sequence byte is detected but any of the following
-   bytes is invalid, the whole sequence is replaced by the replacement
-   method. This mode is most useful with non-US-ASCII character sets,
-   which validly includes multibyte sequences. Note that in this mode
-   control characters are NOT being replaced, because they are valid
-   UTF-8.
-   In **controlcharacters** mode, all bytes which do not represent a
-   printable US-ASCII character (codes 32 to 126) are replaced. Note
-   that this also mangles valid UTF-8 multi-byte sequences, as these are
-   (deliberately) outside of that character range. This mode is most
-   useful if it is known that no characters outside of the US-ASCII
-   alphabet need to be processed.
--  **replacementChar** - default " " (space), a single character
-
-   This is the character that invalid sequences are replaced by.
-   Currently, it MUST be a **printable** US-ASCII character.
+   * - Parameter
+     - Summary
+   * - :ref:`param-mmutf8fix-mode`
+     - .. include:: ../../reference/parameters/mmutf8fix-mode.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-mmutf8fix-replacementchar`
+     - .. include:: ../../reference/parameters/mmutf8fix-replacementchar.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
 
 **Caveats/Known Bugs:**
 
@@ -110,3 +106,9 @@ This is mostly the same as the previous sample, but uses
   module(load="mmutf8fix") if $fromhost-ip == "10.0.0.1" then
   action(type="mmutf8fix" mode="controlcharacters") # all other actions here...
 
+
+.. toctree::
+   :hidden:
+
+   ../../reference/parameters/mmutf8fix-mode
+   ../../reference/parameters/mmutf8fix-replacementchar

--- a/doc/source/reference/parameters/mmutf8fix-mode.rst
+++ b/doc/source/reference/parameters/mmutf8fix-mode.rst
@@ -1,0 +1,49 @@
+.. _param-mmutf8fix-mode:
+.. _mmutf8fix.parameter.action.mode:
+
+Mode
+====
+
+.. index::
+   single: mmutf8fix; Mode
+   single: Mode
+
+.. summary-start
+
+Selects how invalid byte sequences are detected and replaced.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/mmutf8fix`.
+
+:Name: Mode
+:Scope: action
+:Type: string
+:Default: action="utf-8"
+:Required?: no
+:Introduced: 7.5.4
+
+Description
+-----------
+Sets the basic detection mode for invalid byte sequences.
+
+``utf-8`` (default)
+    Checks for proper UTF-8 encoding. Bytes that are not proper UTF-8 sequences are replaced. If a multi-byte start byte is followed by any invalid byte, the entire sequence is replaced. Control characters are not replaced because they are valid UTF-8.
+
+``controlcharacters``
+    Replaces all bytes that do not represent a printable US-ASCII character (codes 32 to 126). This also mangles valid UTF-8 multi-byte sequences, so use it only when characters outside of US-ASCII are not expected.
+
+Action usage
+------------
+.. _param-mmutf8fix-action-mode:
+.. _mmutf8fix.parameter.action.mode-usage:
+
+.. code-block:: rsyslog
+
+   module(load="mmutf8fix")
+
+   action(type="mmutf8fix" mode="controlcharacters")
+
+See also
+--------
+See also :doc:`../../configuration/modules/mmutf8fix`.

--- a/doc/source/reference/parameters/mmutf8fix-replacementchar.rst
+++ b/doc/source/reference/parameters/mmutf8fix-replacementchar.rst
@@ -1,0 +1,43 @@
+.. _param-mmutf8fix-replacementchar:
+.. _mmutf8fix.parameter.action.replacementchar:
+
+replacementChar
+===============
+
+.. index::
+   single: mmutf8fix; replacementChar
+   single: replacementChar
+
+.. summary-start
+
+Defines the printable character used to substitute invalid sequences.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/mmutf8fix`.
+
+:Name: replacementChar
+:Scope: action
+:Type: string
+:Default: action=" "
+:Required?: no
+:Introduced: 7.5.4
+
+Description
+-----------
+This is the character that invalid sequences are replaced by. It must be a printable US-ASCII character.
+
+Action usage
+------------
+.. _param-mmutf8fix-action-replacementchar:
+.. _mmutf8fix.parameter.action.replacementchar-usage:
+
+.. code-block:: rsyslog
+
+   module(load="mmutf8fix")
+
+   action(type="mmutf8fix" replacementChar="#")
+
+See also
+--------
+See also :doc:`../../configuration/modules/mmutf8fix`.


### PR DESCRIPTION
## Summary
- split action parameter docs into reference pages for Mode and replacementChar
- replace inline parameter bullets with list-table and hidden toctree
- document that parameter names are case-insensitive

## Testing
- `./devtools/format-code.sh`
- `make -C doc html`


------
https://chatgpt.com/codex/tasks/task_e_68c53132e14c8330915a33323da19299