### PR TITLE
mmexternal: split parameter docs into reference pages

### DIFF
--- a/doc/source/configuration/modules/mmexternal.rst
+++ b/doc/source/configuration/modules/mmexternal.rst
@@ -24,70 +24,42 @@ Configuration Parameters
 
 .. note::
 
-   Parameter names are case-insensitive.
+   Parameter names are case-insensitive; camelCase is recommended for readability.
 
 
 Action Parameters
 -----------------
 
-binary
-^^^^^^
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
 
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
+   * - Parameter
+     - Summary
+   * - :ref:`param-mmexternal-binary`
+     - .. include:: ../../reference/parameters/mmexternal-binary.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-mmexternal-interface-input`
+     - .. include:: ../../reference/parameters/mmexternal-interface-input.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-mmexternal-output`
+     - .. include:: ../../reference/parameters/mmexternal-output.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-mmexternal-forcesingleinstance`
+     - .. include:: ../../reference/parameters/mmexternal-forcesingleinstance.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
 
-   "string", "none", "yes", "none"
+.. toctree::
+   :hidden:
 
-The name of the external message modification plugin to be called. This
-can be a full path name.
-
-
-interface.input
-^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "msg", "no", "none"
-
-This can either be "msg", "rawmsg" or "fulljson". In case of "fulljson", the
-message object is provided as a json object. Otherwise, the respective
-property is provided. This setting **must** match the external plugin's
-expectations. Check the external plugin documentation for what needs to be used.
-
-
-output
-^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "none", "no", "none"
-
-This is a debug aid. If set, this is a filename where the plugins output
-is logged. Note that the output is also being processed as usual by rsyslog.
-Setting this parameter thus gives insight into the internal processing
-that happens between plugin and rsyslog core.
-
-
-forceSingleInstance
-^^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none"
-
-This is an expert parameter, just like the equivalent *omprog* parameter.
-See the message modification plugin's documentation if it is needed.
+   ../../reference/parameters/mmexternal-binary
+   ../../reference/parameters/mmexternal-interface-input
+   ../../reference/parameters/mmexternal-output
+   ../../reference/parameters/mmexternal-forcesingleinstance
 
 
 Examples

--- a/doc/source/reference/parameters/mmexternal-binary.rst
+++ b/doc/source/reference/parameters/mmexternal-binary.rst
@@ -1,0 +1,46 @@
+.. _param-mmexternal-binary:
+.. _mmexternal.parameter.module.binary:
+
+Binary
+======
+
+.. index::
+   single: mmexternal; Binary
+   single: Binary
+
+.. summary-start
+
+Specifies the external message modification plugin executable that mmexternal invokes.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/mmexternal`.
+
+:Name: Binary
+:Scope: module
+:Type: string
+:Default: module=none
+:Required?: yes
+:Introduced: 8.3.0
+
+Description
+-----------
+The name of the external message modification plugin to be called. This can be a full path name.
+
+Module usage
+------------
+.. _param-mmexternal-module-binary:
+.. _mmexternal.parameter.module.binary-usage:
+
+.. code-block:: rsyslog
+
+   module(load="mmexternal")
+
+   action(
+       type="mmexternal"
+       binary="/path/to/mmexternal.py"
+   )
+
+See also
+--------
+See also :doc:`../../configuration/modules/mmexternal`.

--- a/doc/source/reference/parameters/mmexternal-forcesingleinstance.rst
+++ b/doc/source/reference/parameters/mmexternal-forcesingleinstance.rst
@@ -1,0 +1,47 @@
+.. _param-mmexternal-forcesingleinstance:
+.. _mmexternal.parameter.module.forcesingleinstance:
+
+ForceSingleInstance
+===================
+
+.. index::
+   single: mmexternal; ForceSingleInstance
+   single: ForceSingleInstance
+
+.. summary-start
+
+Enforces that only a single instance of the external message modification plugin runs.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/mmexternal`.
+
+:Name: ForceSingleInstance
+:Scope: module
+:Type: boolean
+:Default: module=off
+:Required?: no
+:Introduced: 8.3.0
+
+Description
+-----------
+This is an expert parameter, just like the equivalent *omprog* parameter. See the message modification plugin's documentation if it is needed.
+
+Module usage
+------------
+.. _param-mmexternal-module-forcesingleinstance:
+.. _mmexternal.parameter.module.forcesingleinstance-usage:
+
+.. code-block:: rsyslog
+
+   module(load="mmexternal")
+
+   action(
+       type="mmexternal"
+       binary="/path/to/mmexternal.py"
+       forceSingleInstance="on"
+   )
+
+See also
+--------
+See also :doc:`../../configuration/modules/mmexternal`.

--- a/doc/source/reference/parameters/mmexternal-interface-input.rst
+++ b/doc/source/reference/parameters/mmexternal-interface-input.rst
@@ -1,0 +1,47 @@
+.. _param-mmexternal-interface-input:
+.. _mmexternal.parameter.module.interface-input:
+
+Interface.input
+================
+
+.. index::
+   single: mmexternal; Interface.input
+   single: Interface.input
+
+.. summary-start
+
+Selects which message representation mmexternal passes to the external plugin.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/mmexternal`.
+
+:Name: Interface.input
+:Scope: module
+:Type: string
+:Default: module=msg
+:Required?: no
+:Introduced: 8.3.0
+
+Description
+-----------
+This can either be "msg", "rawmsg" or "fulljson". In case of "fulljson", the message object is provided as a json object. Otherwise, the respective property is provided. This setting **must** match the external plugin's expectations. Check the external plugin documentation for what needs to be used.
+
+Module usage
+------------
+.. _param-mmexternal-module-interface-input:
+.. _mmexternal.parameter.module.interface-input-usage:
+
+.. code-block:: rsyslog
+
+   module(load="mmexternal")
+
+   action(
+       type="mmexternal"
+       binary="/path/to/mmexternal.py"
+       interface.input="fulljson"
+   )
+
+See also
+--------
+See also :doc:`../../configuration/modules/mmexternal`.

--- a/doc/source/reference/parameters/mmexternal-output.rst
+++ b/doc/source/reference/parameters/mmexternal-output.rst
@@ -1,0 +1,47 @@
+.. _param-mmexternal-output:
+.. _mmexternal.parameter.module.output:
+
+Output
+======
+
+.. index::
+   single: mmexternal; Output
+   single: Output
+
+.. summary-start
+
+Writes the external plugin's standard output to a helper log file for debugging.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/mmexternal`.
+
+:Name: Output
+:Scope: module
+:Type: string
+:Default: module=none
+:Required?: no
+:Introduced: 8.3.0
+
+Description
+-----------
+This is a debug aid. If set, this is a filename where the plugins output is logged. Note that the output is also being processed as usual by rsyslog. Setting this parameter thus gives insight into the internal processing that happens between plugin and rsyslog core.
+
+Module usage
+------------
+.. _param-mmexternal-module-output:
+.. _mmexternal.parameter.module.output-usage:
+
+.. code-block:: rsyslog
+
+   module(load="mmexternal")
+
+   action(
+       type="mmexternal"
+       binary="/path/to/mmexternal.py"
+       output="/var/log/mmexternal-debug.log"
+   )
+
+See also
+--------
+See also :doc:`../../configuration/modules/mmexternal`.


### PR DESCRIPTION
## Summary
- add dedicated mmexternal parameter reference pages for Binary, Interface.input, Output, and ForceSingleInstance with scoped anchors and usage examples
- replace the action parameter tables with a summary list-table and hidden toctree on the module page
- update the configuration parameter note to recommend camelCase casing

## Testing
- make -C doc html

------
https://chatgpt.com/codex/tasks/task_e_68cd56c6beb483308eb90eea75cff4b2