### PR TITLE
mmjsonparse: split parameter docs into reference pages

### DIFF
--- a/doc/source/configuration/modules/mmjsonparse.rst
+++ b/doc/source/configuration/modules/mmjsonparse.rst
@@ -48,59 +48,30 @@ Configuration Parameters
 
 .. note::
 
-   Parameter names are case-insensitive.
+   Parameter names are case-insensitive; camelCase is recommended for readability.
 
 
 Action Parameters
 -----------------
 
-cookie
-^^^^^^
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
 
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "@cee:", "no", "none"
-
-Permits to set the cookie that must be present in front of the
-JSON part of the message.
-
-Most importantly, this can be set to the empty string ("") in order
-to not require any cookie. In this case, leading spaces are permitted
-in front of the JSON. No non-whitespace characters are permitted
-after the JSON. If such is required, mmnormalize must be used.
-
-
-useRawMsg
-^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none"
-
-Specifies if the raw message should be used for normalization (on)
-or just the MSG part of the message (off).
-
-
-container
-^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "$!", "no", "none"
-
-Specifies the JSON container (path) under which parsed elements should be
-placed. By default, all parsed properties are merged into root of
-message properties. You can place them under a subtree, instead. You
-can place them in local variables, also, by setting path="$.".
+   * - Parameter
+     - Summary
+   * - :ref:`param-mmjsonparse-cookie`
+     - .. include:: ../../reference/parameters/mmjsonparse-cookie.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-mmjsonparse-userawmsg`
+     - .. include:: ../../reference/parameters/mmjsonparse-userawmsg.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-mmjsonparse-container`
+     - .. include:: ../../reference/parameters/mmjsonparse-container.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
 
 
 .. _mmjsonparse-parsing-result:
@@ -144,4 +115,12 @@ To permit parsing messages without cookie, use this action statement
 .. code-block:: none
 
   action(type="mmjsonparse" cookie="")
+
+
+.. toctree::
+   :hidden:
+
+   ../../reference/parameters/mmjsonparse-cookie
+   ../../reference/parameters/mmjsonparse-userawmsg
+   ../../reference/parameters/mmjsonparse-container
 

--- a/doc/source/reference/parameters/mmjsonparse-container.rst
+++ b/doc/source/reference/parameters/mmjsonparse-container.rst
@@ -1,0 +1,46 @@
+.. _param-mmjsonparse-container:
+.. _mmjsonparse.parameter.module.container:
+
+container
+=========
+
+.. index::
+   single: mmjsonparse; container
+   single: container
+
+.. summary-start
+
+Sets the JSON container path where parsed properties are stored.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/mmjsonparse`.
+
+:Name: container
+:Scope: module
+:Type: string
+:Default: module=$!
+:Required?: no
+:Introduced: at least 6.6.0, possibly earlier
+
+Description
+-----------
+Specifies the JSON container (path) under which parsed elements should be
+placed. By default, all parsed properties are merged into the root of message
+properties.
+
+You can place parsed data under a subtree instead. You can also store them in
+local variables by setting ``container="$."``.
+
+Module usage
+------------
+.. _param-mmjsonparse-module-container:
+.. _mmjsonparse.parameter.module.container-usage:
+
+.. code-block:: rsyslog
+
+   action(type="mmjsonparse" container="$.parses")
+
+See also
+--------
+See also :doc:`../../configuration/modules/mmjsonparse`.

--- a/doc/source/reference/parameters/mmjsonparse-cookie.rst
+++ b/doc/source/reference/parameters/mmjsonparse-cookie.rst
@@ -1,0 +1,47 @@
+.. _param-mmjsonparse-cookie:
+.. _mmjsonparse.parameter.module.cookie:
+
+cookie
+======
+
+.. index::
+   single: mmjsonparse; cookie
+   single: cookie
+
+.. summary-start
+
+Defines the cookie string that must appear before the JSON content of a message.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/mmjsonparse`.
+
+:Name: cookie
+:Scope: module
+:Type: string
+:Default: module=@cee:
+:Required?: no
+:Introduced: at least 6.6.0, possibly earlier
+
+Description
+-----------
+Permits setting the cookie that must be present in front of the JSON part of
+the message.
+
+Most importantly, this can be set to the empty string ("") to not require any
+cookie. In this case, leading spaces are permitted in front of the JSON. No
+non-whitespace characters are permitted after the JSON. If such is required,
+:doc:`../../configuration/modules/mmnormalize` must be used.
+
+Module usage
+------------
+.. _param-mmjsonparse-module-cookie:
+.. _mmjsonparse.parameter.module.cookie-usage:
+
+.. code-block:: rsyslog
+
+   action(type="mmjsonparse" cookie="@cee:")
+
+See also
+--------
+See also :doc:`../../configuration/modules/mmjsonparse`.

--- a/doc/source/reference/parameters/mmjsonparse-userawmsg.rst
+++ b/doc/source/reference/parameters/mmjsonparse-userawmsg.rst
@@ -1,0 +1,46 @@
+.. _param-mmjsonparse-userawmsg:
+.. _mmjsonparse.parameter.module.userawmsg:
+
+useRawMsg
+=========
+
+.. index::
+   single: mmjsonparse; useRawMsg
+   single: useRawMsg
+
+.. summary-start
+
+Controls whether parsing operates on the raw message instead of only the MSG part.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/mmjsonparse`.
+
+:Name: useRawMsg
+:Scope: module
+:Type: boolean
+:Default: module=off
+:Required?: no
+:Introduced: at least 6.6.0, possibly earlier
+
+Description
+-----------
+Specifies if the raw message should be used for normalization (``on``) or just
+the MSG part of the message (``off``).
+
+Notes
+-----
+- Older documentation referred to this boolean setting as ``binary``.
+
+Module usage
+------------
+.. _param-mmjsonparse-module-userawmsg:
+.. _mmjsonparse.parameter.module.userawmsg-usage:
+
+.. code-block:: rsyslog
+
+   action(type="mmjsonparse" useRawMsg="on")
+
+See also
+--------
+See also :doc:`../../configuration/modules/mmjsonparse`.


### PR DESCRIPTION
## Summary
- split mmjsonparse action parameters into dedicated reference pages for cookie, useRawMsg, and container
- replace the module action parameter section with a summary list-table, updated casing guidance, and a hidden toctree linking the new parameter docs

## Testing
- sphinx-build -n -W -b html doc/source doc/_build/html

------
https://chatgpt.com/codex/tasks/task_e_68d14302c0148330bfbd3901f27f146d