### PR TITLE
mmexternal: add missing scoped usage anchors

### DIFF
--- a/doc/source/reference/parameters/mmexternal-binary.rst
+++ b/doc/source/reference/parameters/mmexternal-binary.rst
@@ -32,6 +32,7 @@ included in the string.
 
 Input usage
 -----------
+.. _param-mmexternal-input-binary:
 .. _mmexternal.parameter.input.binary-usage:
 
 .. code-block:: rsyslog

--- a/doc/source/reference/parameters/mmexternal-forcesingleinstance.rst
+++ b/doc/source/reference/parameters/mmexternal-forcesingleinstance.rst
@@ -44,6 +44,7 @@ This parameter is equivalent to the
 
 Input usage
 -----------
+.. _param-mmexternal-input-forcesingleinstance:
 .. _mmexternal.parameter.input.forcesingleinstance-usage:
 
 .. code-block:: rsyslog

--- a/doc/source/reference/parameters/mmexternal-interface-input.rst
+++ b/doc/source/reference/parameters/mmexternal-interface-input.rst
@@ -46,6 +46,7 @@ external plugin documentation for what needs to be used.
 
 Input usage
 -----------
+.. _param-mmexternal-input-interface-input:
 .. _mmexternal.parameter.input.interface-input-usage:
 
 .. code-block:: rsyslog

--- a/doc/source/reference/parameters/mmexternal-output.rst
+++ b/doc/source/reference/parameters/mmexternal-output.rst
@@ -41,6 +41,7 @@ processing that happens between plugin and rsyslog core.
 
 Input usage
 -----------
+.. _param-mmexternal-input-output:
 .. _mmexternal.parameter.input.output-usage:
 
 .. code-block:: rsyslog


### PR DESCRIPTION
## Summary
- Add param-mmexternal-input anchors beside each usage block to meet reference conventions
- Preserve existing summaries, descriptions, and usage examples

## Testing
- make -C doc html

------
https://chatgpt.com/codex/tasks/task_e_68d7b1df6e808330ae87e96f2d3b07f4