### PR TITLE
im3195: split parameter docs into reference pages

### DIFF
--- a/doc/source/configuration/modules/im3195.rst
+++ b/doc/source/configuration/modules/im3195.rst
@@ -22,29 +22,28 @@ Configuration Parameters
 
 .. note::
 
-   Parameter names are case-insensitive.
+   Parameter names are case-insensitive; camelCase is recommended for readability.
 
 
-Input Parameter
----------------
+Module Parameters
+-----------------
 
-Input3195ListenPort
-^^^^^^^^^^^^^^^^^^^
-
-.. note::
-
-   Parameter is only available in Legacy Format.
+This module has no module-specific parameters.
 
 
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
+Input Parameters
+----------------
 
-   "integer", "601", "no", "``$Input3195ListenPort``"
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
 
-The port on which im3195 listens for RFC 3195 messages. The default
-port is 601 (the IANA-assigned port)
+   * - Parameter
+     - Summary
+   * - :ref:`param-im3195-input3195listenport`
+     - .. include:: ../../reference/parameters/im3195-input3195listenport.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
 
 
 Caveats/Known Bugs
@@ -71,5 +70,11 @@ The following sample accepts syslog messages via RFC 3195 on port 1601.
 
    $ModLoad im3195
    $Input3195ListenPort 1601
+
+
+.. toctree::
+   :hidden:
+
+   ../../reference/parameters/im3195-input3195listenport
 
 

--- a/doc/source/reference/parameters/im3195-input3195listenport.rst
+++ b/doc/source/reference/parameters/im3195-input3195listenport.rst
@@ -1,0 +1,59 @@
+.. _param-im3195-input3195listenport:
+.. _im3195.parameter.input.input3195listenport:
+
+Input3195ListenPort
+===================
+
+.. index::
+   single: im3195; Input3195ListenPort
+   single: Input3195ListenPort
+
+.. summary-start
+
+Listens for RFC 3195 messages on the specified TCP port.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/im3195`.
+
+:Name: Input3195ListenPort
+:Scope: input
+:Type: integer
+:Default: input=601
+:Required?: no
+:Introduced: Not documented
+
+Description
+-----------
+
+.. note::
+
+   This parameter is only available in the legacy configuration format.
+
+The port on which im3195 listens for RFC 3195 messages. The default port is
+601 (the IANA-assigned port).
+
+Input usage
+-----------
+.. _param-im3195-input-input3195listenport:
+.. _im3195.parameter.input.input3195listenport-usage:
+
+.. code-block:: rsyslog
+
+   $Input3195ListenPort 1601
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _im3195.parameter.legacy.input3195listenport:
+
+- $Input3195ListenPort — maps to Input3195ListenPort (status: legacy)
+
+.. index::
+   single: im3195; $Input3195ListenPort
+   single: $Input3195ListenPort
+
+See also
+--------
+See also :doc:`../../configuration/modules/im3195`.


### PR DESCRIPTION
## Summary
- split Input3195ListenPort documentation into a dedicated parameter reference file with legacy directive details
- replace the inline parameter table on the module page with a summary list-table, hidden toctree, and updated casing guidance

## Testing
- make -C doc html

------
https://chatgpt.com/codex/tasks/task_e_68da9492f8448330b6e02b019f0f66fa