### PR TITLE
imdtls: split parameter docs into reference pages; add summary list-tables; fix anchors

### DIFF
--- a/doc/source/configuration/modules/imdtls.rst
+++ b/doc/source/configuration/modules/imdtls.rst
@@ -39,226 +39,81 @@ Configuration Parameters
 
 .. note::
 
-   Parameter names are case-insensitive.
+   Parameter names are case-insensitive; camelCase is recommended for readability.
 
-
-Action Parameters
+Module Parameters
 -----------------
 
-address
-^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "none", "no", "none"
-
-Specifies the IP address on where the imdtls module will listen for
-incoming syslog messages. By default the module will listen on all available
-network connections.
-
-
-port
-^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "4433", "yes", "none"
-
-Specifies the UDP port to which the imdtls module will bind and listen for
-incoming connections. The default port number for DTLS is 4433.
-
-
-timeout
-^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "1800", "no", "none"
-
-Specifies the DTLS session timeout. As DTLS runs on transportless UDP protocol, there are no
-automatic detections of a session timeout. The input will close the DTLS session if no data
-is received from the client for the configured timeout period. The default is 1800 seconds
-which is equal to 30 minutes.
-
-
-name
-^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive", "Available since"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "none", "no", "none"
-
-Unique name to the input module instance. This is useful for identifying the source of
-messages when multiple input modules are used.
-
-
-ruleset
-^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "none", "no", "none"
-
-Determines the ruleset to which the imdtls input will be bound to. This can be
-overridden at the instance level.
-
-
-tls.AuthMode
-^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "none", "no", "none"
-
-Sets the mode used for mutual authentication.
-
-Supported values are either "*fingerprint*\ ", "*name"* or "*certvalid*\ ".
-
-Fingerprint: Authentication based on certificate fingerprint.
-Name: Authentication based on the subjectAltName and, as a fallback, the
-subject common name.
-Certvalid: Requires a valid certificate for authentication.
-Certanon: Anything else will allow anonymous authentication (no client certificate).
-
-
-tls.cacert
-^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "none", "no", "none"
-
-The CA certificate that is being used to verify the client certificates.
-Has to be configured if tls.authmode is set to "*fingerprint*\ ", "*name"* or "*certvalid*\ ".
-
-
-tls.mycert 
-^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "none", "no", "none"
-
-Specifies the certificate file used by imdtls.
-This certificate is presented to peers during the DTLS handshake.
-
-
-tls.myprivkey 
-^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "none", "no", "none"
-
-The private key file corresponding to tls.mycert.
-This key is used for the cryptographic operations in the DTLS handshake.
-
-
-tls.tlscfgcmd 
-^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "none", "no", "none"
-
-Used to pass additional OpenSSL configuration commands. This can be used to fine-tune the OpenSSL
-settings by passing configuration commands to the openssl library.
-OpenSSL Version 1.0.2 or higher is required for this feature.
-A list of possible commands and their valid values can be found in the documentation:
-https://docs.openssl.org/1.0.2/man3/SSL_CONF_cmd/
-
-The setting can be single or multiline, each configuration command is separated by linefeed (\n).
-Command and value are separated by equal sign (=). Here are a few samples:
-
-Example 1
----------
-
-This will allow all protocols except for SSLv2 and SSLv3:
-
-.. code-block:: none
-
-   tls.tlscfgcmd="Protocol=ALL,-SSLv2,-SSLv3"
-
-
-Example 2
----------
-
-This will allow all protocols except for SSLv2, SSLv3 and TLSv1.
-It will also set the minimum protocol to TLSv1.2
-
-.. code-block:: none
-
-   tls.tlscfgcmd="Protocol=ALL,-SSLv2,-SSLv3,-TLSv1
-   MinProtocol=TLSv1.2"
-
-
-TLS.PermittedPeer
-^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "array", "none", "no", "none"
-
-PermittedPeer places access restrictions on this listener. Only peers which
-have been listed in this parameter may connect. The certificate presented 
-by the remote peer is used for it's validation. 
-
-The *peer* parameter lists permitted certificate fingerprints. Note
-that it is an array parameter, so either a single or multiple
-fingerprints can be listed. When a non-permitted peer connects, the
-refusal is logged together with it's fingerprint. So if the
-administrator knows this was a valid request, he can simply add the
-fingerprint by copy and paste from the logfile to rsyslog.conf.
-
-To specify multiple fingerprints, just enclose them in braces like
-this:
-
-.. code-block:: none
-
-   tls.permittedPeer=["SHA1:...1", "SHA1:....2"]
-
-To specify just a single peer, you can either specify the string
-directly or enclose it in braces. You may also use wildcards to match
-a larger number of permitted peers, e.g. ``*.example.com``.
-
-When using wildcards to match larger number of permitted peers, please
-know that the implementation is similar to Syslog RFC5425 which means:
-This wildcard matches any left-most DNS label in the server name.
-That is, the subject ``*.example.com`` matches the server names ``a.example.com``
-and ``b.example.com``, but does not match ``example.com`` or ``a.b.example.com``.
+This module currently has no module-level parameters.
+
+Input Parameters
+----------------
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Parameter
+     - Summary
+   * - :ref:`param-imdtls-address`
+     - .. include:: ../../reference/parameters/imdtls-address.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imdtls-port`
+     - .. include:: ../../reference/parameters/imdtls-port.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imdtls-timeout`
+     - .. include:: ../../reference/parameters/imdtls-timeout.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imdtls-name`
+     - .. include:: ../../reference/parameters/imdtls-name.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imdtls-ruleset`
+     - .. include:: ../../reference/parameters/imdtls-ruleset.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imdtls-tls-authmode`
+     - .. include:: ../../reference/parameters/imdtls-tls-authmode.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imdtls-tls-cacert`
+     - .. include:: ../../reference/parameters/imdtls-tls-cacert.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imdtls-tls-mycert`
+     - .. include:: ../../reference/parameters/imdtls-tls-mycert.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imdtls-tls-myprivkey`
+     - .. include:: ../../reference/parameters/imdtls-tls-myprivkey.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imdtls-tls-tlscfgcmd`
+     - .. include:: ../../reference/parameters/imdtls-tls-tlscfgcmd.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imdtls-tls-permittedpeer`
+     - .. include:: ../../reference/parameters/imdtls-tls-permittedpeer.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+.. toctree::
+   :hidden:
+
+   ../../reference/parameters/imdtls-address
+   ../../reference/parameters/imdtls-port
+   ../../reference/parameters/imdtls-timeout
+   ../../reference/parameters/imdtls-name
+   ../../reference/parameters/imdtls-ruleset
+   ../../reference/parameters/imdtls-tls-authmode
+   ../../reference/parameters/imdtls-tls-cacert
+   ../../reference/parameters/imdtls-tls-mycert
+   ../../reference/parameters/imdtls-tls-myprivkey
+   ../../reference/parameters/imdtls-tls-tlscfgcmd
+   ../../reference/parameters/imdtls-tls-permittedpeer
 
 
 .. _statistics-counter_imdtls_label:

--- a/doc/source/reference/parameters/imdtls-address.rst
+++ b/doc/source/reference/parameters/imdtls-address.rst
@@ -1,0 +1,43 @@
+.. _param-imdtls-address:
+.. _imdtls.parameter.input.address:
+
+Address
+=======
+
+.. index::
+   single: imdtls; Address
+   single: Address
+
+.. summary-start
+
+
+Listens for DTLS syslog messages on the specified local IP address.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imdtls`.
+
+:Name: Address
+:Scope: input
+:Type: word
+:Default: none
+:Required?: no
+:Introduced: v8.2402.0
+
+Description
+-----------
+Specifies the IP address on where the imdtls module will listen for incoming syslog messages. By default the module listens on all available network connections.
+
+Input usage
+-----------
+.. _param-imdtls-input-address:
+.. _imdtls.parameter.input.address-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imdtls")
+   input(type="imdtls" address="192.0.2.1")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imdtls`.

--- a/doc/source/reference/parameters/imdtls-name.rst
+++ b/doc/source/reference/parameters/imdtls-name.rst
@@ -1,0 +1,43 @@
+.. _param-imdtls-name:
+.. _imdtls.parameter.input.name:
+
+Name
+====
+
+.. index::
+   single: imdtls; Name
+   single: Name
+
+.. summary-start
+
+
+Assigns a unique identifier to the imdtls input instance.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imdtls`.
+
+:Name: Name
+:Scope: input
+:Type: word
+:Default: none
+:Required?: no
+:Introduced: v8.2402.0
+
+Description
+-----------
+Provides a unique name to the input module instance. This is useful for identifying the source of messages when multiple input modules are used.
+
+Input usage
+-----------
+.. _param-imdtls-input-name:
+.. _imdtls.parameter.input.name-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imdtls")
+   input(type="imdtls" name="dtlsListener01")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imdtls`.

--- a/doc/source/reference/parameters/imdtls-port.rst
+++ b/doc/source/reference/parameters/imdtls-port.rst
@@ -1,0 +1,43 @@
+.. _param-imdtls-port:
+.. _imdtls.parameter.input.port:
+
+Port
+====
+
+.. index::
+   single: imdtls; Port
+   single: Port
+
+.. summary-start
+
+
+Binds the imdtls listener to the specified UDP port for DTLS traffic.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imdtls`.
+
+:Name: Port
+:Scope: input
+:Type: word
+:Default: 4433
+:Required?: yes
+:Introduced: v8.2402.0
+
+Description
+-----------
+Specifies the UDP port to which the imdtls module will bind and listen for incoming connections. The default port number for DTLS is 4433.
+
+Input usage
+-----------
+.. _param-imdtls-input-port:
+.. _imdtls.parameter.input.port-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imdtls")
+   input(type="imdtls" port="4433")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imdtls`.

--- a/doc/source/reference/parameters/imdtls-ruleset.rst
+++ b/doc/source/reference/parameters/imdtls-ruleset.rst
@@ -1,0 +1,43 @@
+.. _param-imdtls-ruleset:
+.. _imdtls.parameter.input.ruleset:
+
+Ruleset
+=======
+
+.. index::
+   single: imdtls; Ruleset
+   single: Ruleset
+
+.. summary-start
+
+
+Binds received DTLS messages to the specified processing ruleset.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imdtls`.
+
+:Name: Ruleset
+:Scope: input
+:Type: word
+:Default: none
+:Required?: no
+:Introduced: v8.2402.0
+
+Description
+-----------
+Determines the ruleset to which the imdtls input will be bound. This can be overridden at the instance level.
+
+Input usage
+-----------
+.. _param-imdtls-input-ruleset:
+.. _imdtls.parameter.input.ruleset-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imdtls")
+   input(type="imdtls" ruleset="secure-logs")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imdtls`.

--- a/doc/source/reference/parameters/imdtls-timeout.rst
+++ b/doc/source/reference/parameters/imdtls-timeout.rst
@@ -1,0 +1,43 @@
+.. _param-imdtls-timeout:
+.. _imdtls.parameter.input.timeout:
+
+Timeout
+=======
+
+.. index::
+   single: imdtls; Timeout
+   single: Timeout
+
+.. summary-start
+
+
+Closes idle DTLS sessions after the configured inactivity period.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imdtls`.
+
+:Name: Timeout
+:Scope: input
+:Type: word
+:Default: 1800
+:Required?: no
+:Introduced: v8.2402.0
+
+Description
+-----------
+Specifies the DTLS session timeout. As DTLS runs on the transportless UDP protocol, there are no automatic detections of a session timeout. The input closes the DTLS session if no data is received from the client for the configured timeout period. The default is 1800 seconds, which is equal to 30 minutes.
+
+Input usage
+-----------
+.. _param-imdtls-input-timeout:
+.. _imdtls.parameter.input.timeout-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imdtls")
+   input(type="imdtls" timeout="900")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imdtls`.

--- a/doc/source/reference/parameters/imdtls-tls-authmode.rst
+++ b/doc/source/reference/parameters/imdtls-tls-authmode.rst
@@ -1,0 +1,50 @@
+.. _param-imdtls-tls-authmode:
+.. _imdtls.parameter.input.tls-authmode:
+
+tls.AuthMode
+============
+
+.. index::
+   single: imdtls; tls.AuthMode
+   single: tls.AuthMode
+
+.. summary-start
+
+
+Defines the mutual authentication method used for DTLS clients.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imdtls`.
+
+:Name: tls.AuthMode
+:Scope: input
+:Type: string
+:Default: none
+:Required?: no
+:Introduced: v8.2402.0
+
+Description
+-----------
+Sets the mode used for mutual authentication.
+
+Supported values are either ``fingerprint``, ``name`` or ``certvalid``.
+
+* **fingerprint**: Authentication based on certificate fingerprint.
+* **name**: Authentication based on the ``subjectAltName`` and, as a fallback, the subject common name.
+* **certvalid**: Requires a valid certificate for authentication.
+* **certanon**: Anything else will allow anonymous authentication (no client certificate).
+
+Input usage
+-----------
+.. _param-imdtls-input-tls-authmode:
+.. _imdtls.parameter.input.tls-authmode-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imdtls")
+   input(type="imdtls" tls.authMode="certvalid")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imdtls`.

--- a/doc/source/reference/parameters/imdtls-tls-cacert.rst
+++ b/doc/source/reference/parameters/imdtls-tls-cacert.rst
@@ -1,0 +1,45 @@
+.. _param-imdtls-tls-cacert:
+.. _imdtls.parameter.input.tls-cacert:
+
+tls.cacert
+==========
+
+.. index::
+   single: imdtls; tls.cacert
+   single: tls.cacert
+
+.. summary-start
+
+
+Specifies the CA certificate file used to verify DTLS client certificates.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imdtls`.
+
+:Name: tls.cacert
+:Scope: input
+:Type: string
+:Default: none
+:Required?: no
+:Introduced: v8.2402.0
+
+Description
+-----------
+The CA certificate that is being used to verify the client certificates. This file must be configured if ``tls.authMode`` is set to ``fingerprint``, ``name`` or ``certvalid``.
+
+Input usage
+-----------
+.. _param-imdtls-input-tls-cacert:
+.. _imdtls.parameter.input.tls-cacert-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imdtls")
+   input(type="imdtls"
+         tls.cacert="/etc/rsyslog/ca.pem"
+         tls.authMode="certvalid")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imdtls`.

--- a/doc/source/reference/parameters/imdtls-tls-mycert.rst
+++ b/doc/source/reference/parameters/imdtls-tls-mycert.rst
@@ -1,0 +1,45 @@
+.. _param-imdtls-tls-mycert:
+.. _imdtls.parameter.input.tls-mycert:
+
+tls.mycert
+==========
+
+.. index::
+   single: imdtls; tls.mycert
+   single: tls.mycert
+
+.. summary-start
+
+
+Identifies the certificate file the imdtls listener presents to peers.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imdtls`.
+
+:Name: tls.mycert
+:Scope: input
+:Type: string
+:Default: none
+:Required?: no
+:Introduced: v8.2402.0
+
+Description
+-----------
+Specifies the certificate file used by imdtls. This certificate is presented to peers during the DTLS handshake.
+
+Input usage
+-----------
+.. _param-imdtls-input-tls-mycert:
+.. _imdtls.parameter.input.tls-mycert-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imdtls")
+   input(type="imdtls"
+         tls.mycert="/etc/rsyslog/server.pem"
+         tls.myprivkey="/etc/rsyslog/server.key")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imdtls`.

--- a/doc/source/reference/parameters/imdtls-tls-myprivkey.rst
+++ b/doc/source/reference/parameters/imdtls-tls-myprivkey.rst
@@ -1,0 +1,45 @@
+.. _param-imdtls-tls-myprivkey:
+.. _imdtls.parameter.input.tls-myprivkey:
+
+tls.myprivkey
+=============
+
+.. index::
+   single: imdtls; tls.myprivkey
+   single: tls.myprivkey
+
+.. summary-start
+
+
+Points to the private key file paired with ``tls.mycert``.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imdtls`.
+
+:Name: tls.myprivkey
+:Scope: input
+:Type: string
+:Default: none
+:Required?: no
+:Introduced: v8.2402.0
+
+Description
+-----------
+The private key file corresponding to ``tls.mycert``. This key is used for the cryptographic operations in the DTLS handshake.
+
+Input usage
+-----------
+.. _param-imdtls-input-tls-myprivkey:
+.. _imdtls.parameter.input.tls-myprivkey-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imdtls")
+   input(type="imdtls"
+         tls.mycert="/etc/rsyslog/server.pem"
+         tls.myprivkey="/etc/rsyslog/server.key")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imdtls`.

--- a/doc/source/reference/parameters/imdtls-tls-permittedpeer.rst
+++ b/doc/source/reference/parameters/imdtls-tls-permittedpeer.rst
@@ -1,0 +1,56 @@
+.. _param-imdtls-tls-permittedpeer:
+.. _imdtls.parameter.input.tls-permittedpeer:
+
+TLS.PermittedPeer
+=================
+
+.. index::
+   single: imdtls; TLS.PermittedPeer
+   single: TLS.PermittedPeer
+
+.. summary-start
+
+
+Restricts DTLS clients to the listed certificate fingerprints or names.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imdtls`.
+
+:Name: TLS.PermittedPeer
+:Scope: input
+:Type: array
+:Default: none
+:Required?: no
+:Introduced: v8.2402.0
+
+Description
+-----------
+``PermittedPeer`` places access restrictions on this listener. Only peers that have been listed in this parameter may connect. The certificate presented by the remote peer is used for its validation.
+
+The ``peer`` parameter lists permitted certificate fingerprints. Note that it is an array parameter, so either a single or multiple fingerprints can be listed. When a non-permitted peer connects, the refusal is logged together with its fingerprint. If the administrator knows this was a valid request, they can simply add the fingerprint by copy and paste from the logfile to ``rsyslog.conf``.
+
+To specify multiple fingerprints, enclose them in braces like this:
+
+.. code-block:: none
+
+   tls.permittedPeer=["SHA1:...1", "SHA1:....2"]
+
+To specify just a single peer, you can either specify the string directly or enclose it in braces. You may also use wildcards to match a larger number of permitted peers, e.g. ``*.example.com``.
+
+When using wildcards to match a larger number of permitted peers, the implementation is similar to Syslog RFC5425. This wildcard matches any left-most DNS label in the server name. That is, the subject ``*.example.com`` matches the server names ``a.example.com`` and ``b.example.com``, but does not match ``example.com`` or ``a.b.example.com``.
+
+Input usage
+-----------
+.. _param-imdtls-input-tls-permittedpeer:
+.. _imdtls.parameter.input.tls-permittedpeer-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imdtls")
+   input(type="imdtls"
+         tls.permittedPeer=["SHA1:11223344556677889900AABBCCDDEEFF00112233"])
+
+See also
+--------
+See also :doc:`../../configuration/modules/imdtls`.

--- a/doc/source/reference/parameters/imdtls-tls-tlscfgcmd.rst
+++ b/doc/source/reference/parameters/imdtls-tls-tlscfgcmd.rst
@@ -1,0 +1,59 @@
+.. _param-imdtls-tls-tlscfgcmd:
+.. _imdtls.parameter.input.tls-tlscfgcmd:
+
+tls.tlscfgcmd
+=============
+
+.. index::
+   single: imdtls; tls.tlscfgcmd
+   single: tls.tlscfgcmd
+
+.. summary-start
+
+
+Passes additional OpenSSL configuration commands to fine-tune DTLS handling.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imdtls`.
+
+:Name: tls.tlscfgcmd
+:Scope: input
+:Type: string
+:Default: none
+:Required?: no
+:Introduced: v8.2402.0
+
+Description
+-----------
+Used to pass additional OpenSSL configuration commands. This can be used to fine-tune the OpenSSL settings by passing configuration commands to the OpenSSL library. OpenSSL version 1.0.2 or higher is required for this feature. A list of possible commands and their valid values can be found in the documentation: https://docs.openssl.org/1.0.2/man3/SSL_CONF_cmd/.
+
+The setting can be single or multiline, each configuration command is separated by linefeed (``\n``). Command and value are separated by equal sign (``=``).
+
+Examples
+~~~~~~~~
+This will allow all protocols except for SSLv2 and SSLv3:
+
+.. code-block:: none
+
+   tls.tlscfgcmd="Protocol=ALL,-SSLv2,-SSLv3"
+
+This will allow all protocols except for SSLv2, SSLv3 and TLSv1 and will also set the minimum protocol to TLSv1.2:
+
+.. code-block:: none
+
+   tls.tlscfgcmd="Protocol=ALL,-SSLv2,-SSLv3,-TLSv1\nMinProtocol=TLSv1.2"
+
+Input usage
+-----------
+.. _param-imdtls-input-tls-tlscfgcmd:
+.. _imdtls.parameter.input.tls-tlscfgcmd-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imdtls")
+   input(type="imdtls" tls.tlscfgcmd="Protocol=ALL,-SSLv2,-SSLv3")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imdtls`.


### PR DESCRIPTION
## Summary
- split the imdtls input parameters into dedicated reference pages with canonical anchors, usage examples, and preserved descriptions
- replace the inline parameter tables on the imdtls module page with summary list-tables, a camelCase note, and a hidden toctree linking the new references

## Testing
- make -C doc html

------
https://chatgpt.com/codex/tasks/task_e_68e11b40191c83309b0460dadbf5bb13