### PR TITLE
ommongodb: split parameter docs into reference pages

### DIFF
--- a/doc/source/configuration/modules/ommongodb.rst
+++ b/doc/source/configuration/modules/ommongodb.rst
@@ -21,129 +21,46 @@ Configuration Parameters
 
 .. note::
 
-   Parameter names are case-insensitive.
+   Parameter names are case-insensitive; camelCase is recommended for readability.
 
 
 Action Parameters
 -----------------
 
-UriStr
-^^^^^^
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
 
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "none", "no", "none"
-
-MongoDB connection string, as defined by the MongoDB String URI Format (See: https://docs.mongodb.com/manual/reference/connection-string/). If uristr is defined, following directives will be ignored: server, serverport, uid, pwd.
-
-
-SSL_Cert
-^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "none", "no", "none"
-
-Absolute path to the X509 certificate you want to use for TLS client authentication. This is optional.
-
-
-SSL_Ca
-^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "none", "no", "none"
-
-Absolute path to the trusted X509 CA certificate that signed the mongoDB server certificate. This is optional.
-
-
-db
-^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "syslog", "no", "none"
-
-Database to use.
-
-
-Collection
-^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "log", "no", "none"
-
-Collection to use.
-
-
-Allowed_Error_Codes
-^^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "array", "no", "no", "none"
-
-The list of error codes returned by MongoDB you want ommongodb to ignore.
-Please use the following format: allowed_error_codes=["11000","47"].
-
-
-Template
-^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "OMSR_TPL_AS_MSG", "no", "none"
-
-Template to use when submitting messages.
-
-Note rsyslog contains a canned default template to write to the MongoDB.
-It will be used automatically if no other template is specified to be
-used. This template is:
-
-.. code-block:: none
-
-   template(name="BSON" type="string" string="\\"sys\\" : \\"%hostname%\\",
-   \\"time\\" : \\"%timereported:::rfc3339%\\", \\"time\_rcvd\\" :
-   \\"%timegenerated:::rfc3339%\\", \\"msg\\" : \\"%msg%\\",
-   \\"syslog\_fac\\" : \\"%syslogfacility%\\", \\"syslog\_server\\" :
-   \\"%syslogseverity%\\", \\"syslog\_tag\\" : \\"%syslogtag%\\",
-   \\"procid\\" : \\"%programname%\\", \\"pid\\" : \\"%procid%\\",
-   \\"level\\" : \\"%syslogpriority-text%\\"")
-
-
-This creates the BSON document needed for MongoDB if no template is
-specified. The default schema is aligned to CEE and project lumberjack.
-As such, the field names are standard lumberjack field names, and
-**not** `rsyslog property names <property_replacer.html>`_. When
-specifying templates, be sure to use rsyslog property names as given in
-the table. If you would like to use lumberjack-based field names inside
-MongoDB (which probably is useful depending on the use case), you need
-to select fields names based on the lumberjack schema. If you just want
-to use a subset of the fields, but with lumberjack names, you can look
-up the mapping in the default template. For example, the lumberjack
-field "level" contains the rsyslog property "syslogpriority-text".
+   * - Parameter
+     - Summary
+   * - :ref:`param-ommongodb-uristr`
+     - .. include:: ../../reference/parameters/ommongodb-uristr.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-ommongodb-ssl-cert`
+     - .. include:: ../../reference/parameters/ommongodb-ssl-cert.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-ommongodb-ssl-ca`
+     - .. include:: ../../reference/parameters/ommongodb-ssl-ca.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-ommongodb-db`
+     - .. include:: ../../reference/parameters/ommongodb-db.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-ommongodb-collection`
+     - .. include:: ../../reference/parameters/ommongodb-collection.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-ommongodb-allowed-error-codes`
+     - .. include:: ../../reference/parameters/ommongodb-allowed-error-codes.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-ommongodb-template`
+     - .. include:: ../../reference/parameters/ommongodb-template.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
 
 
 Examples
@@ -192,58 +109,41 @@ Deprecated Parameters
 Action Parameters
 -----------------
 
-Server
-^^^^^^
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
 
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "127.0.0.1", "no", "none"
-
-Name or address of the MongoDB server.
-
-
-ServerPorted
-^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "27017", "no", "none"
-
-Permits to select a non-standard port for the MongoDB server. The
-default is 0, which means the system default port is used. There is
-no need to specify this parameter unless you know the server is
-running on a non-standard listen port.
+   * - Parameter
+     - Summary
+   * - :ref:`param-ommongodb-server`
+     - .. include:: ../../reference/parameters/ommongodb-server.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-ommongodb-serverported`
+     - .. include:: ../../reference/parameters/ommongodb-serverported.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-ommongodb-uid`
+     - .. include:: ../../reference/parameters/ommongodb-uid.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-ommongodb-pwd`
+     - .. include:: ../../reference/parameters/ommongodb-pwd.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
 
 
-UID
-^^^
+.. toctree::
+   :hidden:
 
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "none", "no", "none"
-
-Logon userid used to connect to server. Must have proper permissions.
-
-
-PWD
-^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "none", "no", "none"
-
-The user's password.
-
-
+   ../../reference/parameters/ommongodb-uristr
+   ../../reference/parameters/ommongodb-ssl-cert
+   ../../reference/parameters/ommongodb-ssl-ca
+   ../../reference/parameters/ommongodb-db
+   ../../reference/parameters/ommongodb-collection
+   ../../reference/parameters/ommongodb-allowed-error-codes
+   ../../reference/parameters/ommongodb-template
+   ../../reference/parameters/ommongodb-server
+   ../../reference/parameters/ommongodb-serverported
+   ../../reference/parameters/ommongodb-uid
+   ../../reference/parameters/ommongodb-pwd

--- a/doc/source/reference/parameters/ommongodb-allowed-error-codes.rst
+++ b/doc/source/reference/parameters/ommongodb-allowed-error-codes.rst
@@ -1,5 +1,5 @@
 .. _param-ommongodb-allowed-error-codes:
-.. _ommongodb.parameter.module.allowed-error-codes:
+.. _ommongodb.parameter.input.allowed-error-codes:
 
 Allowed_Error_Codes
 ===================
@@ -17,9 +17,9 @@ Lists MongoDB error codes that ommongodb should ignore instead of treating as fa
 This parameter applies to :doc:`../../configuration/modules/ommongodb`.
 
 :Name: Allowed_Error_Codes
-:Scope: module
+:Scope: input
 :Type: array
-:Default: module=no
+:Default: input=no
 :Required?: no
 :Introduced: at least 7.x, possibly earlier
 
@@ -28,10 +28,10 @@ Description
 The list of error codes returned by MongoDB you want ommongodb to ignore. Use the
 following format: ``allowedErrorCodes=["11000","47"]``.
 
-Module usage
-------------
-.. _param-ommongodb-module-allowed-error-codes:
-.. _ommongodb.parameter.module.allowed-error-codes-usage:
+Input usage
+-----------
+.. _param-ommongodb-input-allowed-error-codes:
+.. _ommongodb.parameter.input.allowed-error-codes-usage:
 
 .. code-block:: rsyslog
 

--- a/doc/source/reference/parameters/ommongodb-allowed-error-codes.rst
+++ b/doc/source/reference/parameters/ommongodb-allowed-error-codes.rst
@@ -26,7 +26,7 @@ This parameter applies to :doc:`../../configuration/modules/ommongodb`.
 Description
 -----------
 The list of error codes returned by MongoDB you want ommongodb to ignore. Use the
-following format: ``allowed_error_codes=["11000","47"]``.
+following format: ``allowedErrorCodes=["11000","47"]``.
 
 Module usage
 ------------

--- a/doc/source/reference/parameters/ommongodb-allowed-error-codes.rst
+++ b/doc/source/reference/parameters/ommongodb-allowed-error-codes.rst
@@ -1,6 +1,11 @@
 .. _param-ommongodb-allowed-error-codes:
 .. _ommongodb.parameter.input.allowed-error-codes:
 
+.. meta::
+   :description: Lists MongoDB error codes that ommongodb can ignore instead of
+                 treating as failures.
+   :keywords: rsyslog, ommongodb, allowed error codes, mongodb action parameter
+
 Allowed_Error_Codes
 ===================
 
@@ -10,7 +15,8 @@ Allowed_Error_Codes
 
 .. summary-start
 
-Lists MongoDB error codes that ommongodb should ignore instead of treating as failures.
+Lists MongoDB error codes that ommongodb should ignore instead of treating as
+failures.
 
 .. summary-end
 
@@ -25,8 +31,8 @@ This parameter applies to :doc:`../../configuration/modules/ommongodb`.
 
 Description
 -----------
-The list of error codes returned by MongoDB you want ommongodb to ignore. Use the
-following format: ``allowedErrorCodes=["11000","47"]``.
+The list of error codes returned by MongoDB you want ommongodb to ignore. Use
+the following format: ``allowedErrorCodes=["11000","47"]``.
 
 Input usage
 -----------

--- a/doc/source/reference/parameters/ommongodb-allowed-error-codes.rst
+++ b/doc/source/reference/parameters/ommongodb-allowed-error-codes.rst
@@ -1,0 +1,46 @@
+.. _param-ommongodb-allowed-error-codes:
+.. _ommongodb.parameter.module.allowed-error-codes:
+
+Allowed_Error_Codes
+===================
+
+.. index::
+   single: ommongodb; Allowed_Error_Codes
+   single: Allowed_Error_Codes
+
+.. summary-start
+
+Lists MongoDB error codes that ommongodb should ignore instead of treating as failures.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/ommongodb`.
+
+:Name: Allowed_Error_Codes
+:Scope: module
+:Type: array
+:Default: module=no
+:Required?: no
+:Introduced: at least 7.x, possibly earlier
+
+Description
+-----------
+The list of error codes returned by MongoDB you want ommongodb to ignore. Use the
+following format: ``allowed_error_codes=["11000","47"]``.
+
+Module usage
+------------
+.. _param-ommongodb-module-allowed-error-codes:
+.. _ommongodb.parameter.module.allowed-error-codes-usage:
+
+.. code-block:: rsyslog
+
+   module(load="ommongodb")
+   action(type="ommongodb"
+          uriStr="mongodb://vulture:9091/?ssl=true"
+          allowedErrorCodes=["11000", "47"]
+          db="syslog" collection="log")
+
+See also
+--------
+See also :doc:`../../configuration/modules/ommongodb`.

--- a/doc/source/reference/parameters/ommongodb-collection.rst
+++ b/doc/source/reference/parameters/ommongodb-collection.rst
@@ -1,6 +1,11 @@
 .. _param-ommongodb-collection:
 .. _ommongodb.parameter.input.collection:
 
+.. meta::
+   :description: Specifies the MongoDB collection within the selected database
+                 for log entries.
+   :keywords: rsyslog, ommongodb, collection, mongodb action parameter
+
 Collection
 ==========
 

--- a/doc/source/reference/parameters/ommongodb-collection.rst
+++ b/doc/source/reference/parameters/ommongodb-collection.rst
@@ -1,5 +1,5 @@
 .. _param-ommongodb-collection:
-.. _ommongodb.parameter.module.collection:
+.. _ommongodb.parameter.input.collection:
 
 Collection
 ==========
@@ -17,9 +17,9 @@ Specifies the MongoDB collection within the selected database for log entries.
 This parameter applies to :doc:`../../configuration/modules/ommongodb`.
 
 :Name: Collection
-:Scope: module
+:Scope: input
 :Type: word
-:Default: module=log
+:Default: input=log
 :Required?: no
 :Introduced: at least 7.x, possibly earlier
 
@@ -27,10 +27,10 @@ Description
 -----------
 Collection to use.
 
-Module usage
-------------
-.. _param-ommongodb-module-collection:
-.. _ommongodb.parameter.module.collection-usage:
+Input usage
+-----------
+.. _param-ommongodb-input-collection:
+.. _ommongodb.parameter.input.collection-usage:
 
 .. code-block:: rsyslog
 

--- a/doc/source/reference/parameters/ommongodb-collection.rst
+++ b/doc/source/reference/parameters/ommongodb-collection.rst
@@ -1,0 +1,44 @@
+.. _param-ommongodb-collection:
+.. _ommongodb.parameter.module.collection:
+
+Collection
+==========
+
+.. index::
+   single: ommongodb; Collection
+   single: Collection
+
+.. summary-start
+
+Specifies the MongoDB collection within the selected database for log entries.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/ommongodb`.
+
+:Name: Collection
+:Scope: module
+:Type: word
+:Default: module=log
+:Required?: no
+:Introduced: at least 7.x, possibly earlier
+
+Description
+-----------
+Collection to use.
+
+Module usage
+------------
+.. _param-ommongodb-module-collection:
+.. _ommongodb.parameter.module.collection-usage:
+
+.. code-block:: rsyslog
+
+   module(load="ommongodb")
+   action(type="ommongodb"
+          uriStr="mongodb://vulture:9091/?ssl=true"
+          db="syslog" collection="log")
+
+See also
+--------
+See also :doc:`../../configuration/modules/ommongodb`.

--- a/doc/source/reference/parameters/ommongodb-db.rst
+++ b/doc/source/reference/parameters/ommongodb-db.rst
@@ -1,0 +1,44 @@
+.. _param-ommongodb-db:
+.. _ommongodb.parameter.module.db:
+
+db
+==
+
+.. index::
+   single: ommongodb; db
+   single: db
+
+.. summary-start
+
+Selects the MongoDB database where rsyslog should store log records.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/ommongodb`.
+
+:Name: db
+:Scope: module
+:Type: word
+:Default: module=syslog
+:Required?: no
+:Introduced: at least 7.x, possibly earlier
+
+Description
+-----------
+Database to use.
+
+Module usage
+------------
+.. _param-ommongodb-module-db:
+.. _ommongodb.parameter.module.db-usage:
+
+.. code-block:: rsyslog
+
+   module(load="ommongodb")
+   action(type="ommongodb"
+          uriStr="mongodb://vulture:9091/?ssl=true"
+          db="syslog" collection="log")
+
+See also
+--------
+See also :doc:`../../configuration/modules/ommongodb`.

--- a/doc/source/reference/parameters/ommongodb-db.rst
+++ b/doc/source/reference/parameters/ommongodb-db.rst
@@ -1,6 +1,10 @@
 .. _param-ommongodb-db:
 .. _ommongodb.parameter.input.db:
 
+.. meta::
+   :description: Selects the MongoDB database where rsyslog stores log records.
+   :keywords: rsyslog, ommongodb, db, mongodb action parameter
+
 db
 ==
 

--- a/doc/source/reference/parameters/ommongodb-db.rst
+++ b/doc/source/reference/parameters/ommongodb-db.rst
@@ -1,5 +1,5 @@
 .. _param-ommongodb-db:
-.. _ommongodb.parameter.module.db:
+.. _ommongodb.parameter.input.db:
 
 db
 ==
@@ -17,9 +17,9 @@ Selects the MongoDB database where rsyslog should store log records.
 This parameter applies to :doc:`../../configuration/modules/ommongodb`.
 
 :Name: db
-:Scope: module
+:Scope: input
 :Type: word
-:Default: module=syslog
+:Default: input=syslog
 :Required?: no
 :Introduced: at least 7.x, possibly earlier
 
@@ -27,10 +27,10 @@ Description
 -----------
 Database to use.
 
-Module usage
-------------
-.. _param-ommongodb-module-db:
-.. _ommongodb.parameter.module.db-usage:
+Input usage
+-----------
+.. _param-ommongodb-input-db:
+.. _ommongodb.parameter.input.db-usage:
 
 .. code-block:: rsyslog
 

--- a/doc/source/reference/parameters/ommongodb-pwd.rst
+++ b/doc/source/reference/parameters/ommongodb-pwd.rst
@@ -1,6 +1,11 @@
 .. _param-ommongodb-pwd:
 .. _ommongodb.parameter.input.pwd:
 
+.. meta::
+   :description: Provides the password for MongoDB authentication; deprecated
+                 in favor of credentials in ``UriStr``.
+   :keywords: rsyslog, ommongodb, password, mongodb action parameter
+
 PWD
 ===
 
@@ -10,7 +15,8 @@ PWD
 
 .. summary-start
 
-Provides the password for MongoDB authentication (deprecated; prefer credentials in ``UriStr``).
+Provides the password for MongoDB authentication (deprecated; prefer
+credentials in ``UriStr``).
 
 .. summary-end
 

--- a/doc/source/reference/parameters/ommongodb-pwd.rst
+++ b/doc/source/reference/parameters/ommongodb-pwd.rst
@@ -1,5 +1,5 @@
 .. _param-ommongodb-pwd:
-.. _ommongodb.parameter.module.pwd:
+.. _ommongodb.parameter.input.pwd:
 
 PWD
 ===
@@ -17,9 +17,9 @@ Provides the password for MongoDB authentication (deprecated; prefer credentials
 This parameter applies to :doc:`../../configuration/modules/ommongodb`.
 
 :Name: PWD
-:Scope: module
+:Scope: input
 :Type: word
-:Default: module=none
+:Default: input=none
 :Required?: no
 :Introduced: at least 7.x, possibly earlier
 
@@ -28,10 +28,10 @@ Description
 The user's password. This parameter is deprecated and should not be used for new
 configurations.
 
-Module usage
-------------
-.. _param-ommongodb-module-pwd:
-.. _ommongodb.parameter.module.pwd-usage:
+Input usage
+-----------
+.. _param-ommongodb-input-pwd:
+.. _ommongodb.parameter.input.pwd-usage:
 
 .. code-block:: rsyslog
 

--- a/doc/source/reference/parameters/ommongodb-pwd.rst
+++ b/doc/source/reference/parameters/ommongodb-pwd.rst
@@ -1,0 +1,45 @@
+.. _param-ommongodb-pwd:
+.. _ommongodb.parameter.module.pwd:
+
+PWD
+===
+
+.. index::
+   single: ommongodb; PWD
+   single: PWD
+
+.. summary-start
+
+Provides the password for MongoDB authentication (deprecated; prefer credentials in ``UriStr``).
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/ommongodb`.
+
+:Name: PWD
+:Scope: module
+:Type: word
+:Default: module=none
+:Required?: no
+:Introduced: at least 7.x, possibly earlier
+
+Description
+-----------
+The user's password. This parameter is deprecated and should not be used for new
+configurations.
+
+Module usage
+------------
+.. _param-ommongodb-module-pwd:
+.. _ommongodb.parameter.module.pwd-usage:
+
+.. code-block:: rsyslog
+
+   module(load="ommongodb")
+   action(type="ommongodb"
+          server="mongoserver.example.com" db="syslog" collection="log"
+          uid="user" pwd="pwd")
+
+See also
+--------
+See also :doc:`../../configuration/modules/ommongodb`.

--- a/doc/source/reference/parameters/ommongodb-server.rst
+++ b/doc/source/reference/parameters/ommongodb-server.rst
@@ -1,0 +1,45 @@
+.. _param-ommongodb-server:
+.. _ommongodb.parameter.module.server:
+
+Server
+======
+
+.. index::
+   single: ommongodb; Server
+   single: Server
+
+.. summary-start
+
+Provides the MongoDB server host name or address (deprecated in favor of ``UriStr``).
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/ommongodb`.
+
+:Name: Server
+:Scope: module
+:Type: word
+:Default: module=127.0.0.1
+:Required?: no
+:Introduced: at least 7.x, possibly earlier
+
+Description
+-----------
+Name or address of the MongoDB server. This parameter is deprecated and should
+not be used for new configurations.
+
+Module usage
+------------
+.. _param-ommongodb-module-server:
+.. _ommongodb.parameter.module.server-usage:
+
+.. code-block:: rsyslog
+
+   module(load="ommongodb")
+   action(type="ommongodb"
+          server="mongoserver.example.com" db="syslog" collection="log"
+          uid="user" pwd="pwd")
+
+See also
+--------
+See also :doc:`../../configuration/modules/ommongodb`.

--- a/doc/source/reference/parameters/ommongodb-server.rst
+++ b/doc/source/reference/parameters/ommongodb-server.rst
@@ -1,6 +1,11 @@
 .. _param-ommongodb-server:
 .. _ommongodb.parameter.input.server:
 
+.. meta::
+   :description: Provides the MongoDB server host name or address; deprecated
+                 in favor of ``UriStr``.
+   :keywords: rsyslog, ommongodb, server, mongodb action parameter
+
 Server
 ======
 
@@ -10,7 +15,8 @@ Server
 
 .. summary-start
 
-Provides the MongoDB server host name or address (deprecated in favor of ``UriStr``).
+Provides the MongoDB server host name or address (deprecated in favor of
+``UriStr``).
 
 .. summary-end
 

--- a/doc/source/reference/parameters/ommongodb-server.rst
+++ b/doc/source/reference/parameters/ommongodb-server.rst
@@ -1,5 +1,5 @@
 .. _param-ommongodb-server:
-.. _ommongodb.parameter.module.server:
+.. _ommongodb.parameter.input.server:
 
 Server
 ======
@@ -17,9 +17,9 @@ Provides the MongoDB server host name or address (deprecated in favor of ``UriSt
 This parameter applies to :doc:`../../configuration/modules/ommongodb`.
 
 :Name: Server
-:Scope: module
+:Scope: input
 :Type: word
-:Default: module=127.0.0.1
+:Default: input=127.0.0.1
 :Required?: no
 :Introduced: at least 7.x, possibly earlier
 
@@ -28,10 +28,10 @@ Description
 Name or address of the MongoDB server. This parameter is deprecated and should
 not be used for new configurations.
 
-Module usage
-------------
-.. _param-ommongodb-module-server:
-.. _ommongodb.parameter.module.server-usage:
+Input usage
+-----------
+.. _param-ommongodb-input-server:
+.. _ommongodb.parameter.input.server-usage:
 
 .. code-block:: rsyslog
 

--- a/doc/source/reference/parameters/ommongodb-serverported.rst
+++ b/doc/source/reference/parameters/ommongodb-serverported.rst
@@ -1,0 +1,47 @@
+.. _param-ommongodb-serverported:
+.. _ommongodb.parameter.module.serverported:
+
+ServerPorted
+============
+
+.. index::
+   single: ommongodb; ServerPorted
+   single: ServerPorted
+
+.. summary-start
+
+Sets a non-standard MongoDB server port number (deprecated; use ``UriStr`` instead).
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/ommongodb`.
+
+:Name: ServerPorted
+:Scope: module
+:Type: word
+:Default: module=27017
+:Required?: no
+:Introduced: at least 7.x, possibly earlier
+
+Description
+-----------
+Permits to select a non-standard port for the MongoDB server. The default is 0,
+which means the system default port is used. There is no need to specify this
+parameter unless you know the server is running on a non-standard listen port.
+This parameter is deprecated and should not be used for new configurations.
+
+Module usage
+------------
+.. _param-ommongodb-module-serverported:
+.. _ommongodb.parameter.module.serverported-usage:
+
+.. code-block:: rsyslog
+
+   module(load="ommongodb")
+   action(type="ommongodb"
+          server="mongoserver.example.com" serverPorted="27017"
+          db="syslog" collection="log" uid="user" pwd="pwd")
+
+See also
+--------
+See also :doc:`../../configuration/modules/ommongodb`.

--- a/doc/source/reference/parameters/ommongodb-serverported.rst
+++ b/doc/source/reference/parameters/ommongodb-serverported.rst
@@ -1,6 +1,11 @@
 .. _param-ommongodb-serverported:
 .. _ommongodb.parameter.input.serverported:
 
+.. meta::
+   :description: Sets a non-standard MongoDB server port number; deprecated in
+                 favor of ``UriStr``.
+   :keywords: rsyslog, ommongodb, server port, mongodb action parameter
+
 ServerPorted
 ============
 
@@ -10,7 +15,8 @@ ServerPorted
 
 .. summary-start
 
-Sets a non-standard MongoDB server port number (deprecated; use ``UriStr`` instead).
+Sets a non-standard MongoDB server port number (deprecated; use ``UriStr``
+instead).
 
 .. summary-end
 

--- a/doc/source/reference/parameters/ommongodb-serverported.rst
+++ b/doc/source/reference/parameters/ommongodb-serverported.rst
@@ -1,5 +1,5 @@
 .. _param-ommongodb-serverported:
-.. _ommongodb.parameter.module.serverported:
+.. _ommongodb.parameter.input.serverported:
 
 ServerPorted
 ============
@@ -17,9 +17,9 @@ Sets a non-standard MongoDB server port number (deprecated; use ``UriStr`` inste
 This parameter applies to :doc:`../../configuration/modules/ommongodb`.
 
 :Name: ServerPorted
-:Scope: module
+:Scope: input
 :Type: word
-:Default: module=27017
+:Default: input=27017
 :Required?: no
 :Introduced: at least 7.x, possibly earlier
 
@@ -30,10 +30,10 @@ to specify this parameter unless you know the server is running on a
 non-standard listen port. This parameter is deprecated and should not be used
 for new configurations.
 
-Module usage
-------------
-.. _param-ommongodb-module-serverported:
-.. _ommongodb.parameter.module.serverported-usage:
+Input usage
+-----------
+.. _param-ommongodb-input-serverported:
+.. _ommongodb.parameter.input.serverported-usage:
 
 .. code-block:: rsyslog
 

--- a/doc/source/reference/parameters/ommongodb-serverported.rst
+++ b/doc/source/reference/parameters/ommongodb-serverported.rst
@@ -25,10 +25,10 @@ This parameter applies to :doc:`../../configuration/modules/ommongodb`.
 
 Description
 -----------
-Permits to select a non-standard port for the MongoDB server. The default is 0,
-which means the system default port is used. There is no need to specify this
-parameter unless you know the server is running on a non-standard listen port.
-This parameter is deprecated and should not be used for new configurations.
+Permits to select a non-standard port for the MongoDB server. There is no need
+to specify this parameter unless you know the server is running on a
+non-standard listen port. This parameter is deprecated and should not be used
+for new configurations.
 
 Module usage
 ------------

--- a/doc/source/reference/parameters/ommongodb-ssl-ca.rst
+++ b/doc/source/reference/parameters/ommongodb-ssl-ca.rst
@@ -1,5 +1,5 @@
 .. _param-ommongodb-ssl-ca:
-.. _ommongodb.parameter.module.ssl-ca:
+.. _ommongodb.parameter.input.ssl-ca:
 
 SSL_Ca
 ======
@@ -17,9 +17,9 @@ Provides the absolute path to the trusted X.509 CA certificate that signed the M
 This parameter applies to :doc:`../../configuration/modules/ommongodb`.
 
 :Name: SSL_Ca
-:Scope: module
+:Scope: input
 :Type: word
-:Default: module=none
+:Default: input=none
 :Required?: no
 :Introduced: at least 7.x, possibly earlier
 
@@ -28,10 +28,10 @@ Description
 Absolute path to the trusted X509 CA certificate that signed the MongoDB server
 certificate. This is optional.
 
-Module usage
-------------
-.. _param-ommongodb-module-ssl-ca:
-.. _ommongodb.parameter.module.ssl-ca-usage:
+Input usage
+-----------
+.. _param-ommongodb-input-ssl-ca:
+.. _ommongodb.parameter.input.ssl-ca-usage:
 
 .. code-block:: rsyslog
 

--- a/doc/source/reference/parameters/ommongodb-ssl-ca.rst
+++ b/doc/source/reference/parameters/ommongodb-ssl-ca.rst
@@ -1,0 +1,46 @@
+.. _param-ommongodb-ssl-ca:
+.. _ommongodb.parameter.module.ssl-ca:
+
+SSL_Ca
+======
+
+.. index::
+   single: ommongodb; SSL_Ca
+   single: SSL_Ca
+
+.. summary-start
+
+Provides the absolute path to the trusted X.509 CA certificate that signed the MongoDB server certificate.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/ommongodb`.
+
+:Name: SSL_Ca
+:Scope: module
+:Type: word
+:Default: module=none
+:Required?: no
+:Introduced: at least 7.x, possibly earlier
+
+Description
+-----------
+Absolute path to the trusted X509 CA certificate that signed the mongoDB server
+certificate. This is optional.
+
+Module usage
+------------
+.. _param-ommongodb-module-ssl-ca:
+.. _ommongodb.parameter.module.ssl-ca-usage:
+
+.. code-block:: rsyslog
+
+   module(load="ommongodb")
+   action(type="ommongodb"
+          uriStr="mongodb://vulture:9091/?ssl=true"
+          sslCa="/var/db/mongodb/ca.pem"
+          db="logs" collection="syslog")
+
+See also
+--------
+See also :doc:`../../configuration/modules/ommongodb`.

--- a/doc/source/reference/parameters/ommongodb-ssl-ca.rst
+++ b/doc/source/reference/parameters/ommongodb-ssl-ca.rst
@@ -25,7 +25,7 @@ This parameter applies to :doc:`../../configuration/modules/ommongodb`.
 
 Description
 -----------
-Absolute path to the trusted X509 CA certificate that signed the mongoDB server
+Absolute path to the trusted X509 CA certificate that signed the MongoDB server
 certificate. This is optional.
 
 Module usage

--- a/doc/source/reference/parameters/ommongodb-ssl-ca.rst
+++ b/doc/source/reference/parameters/ommongodb-ssl-ca.rst
@@ -1,6 +1,11 @@
 .. _param-ommongodb-ssl-ca:
 .. _ommongodb.parameter.input.ssl-ca:
 
+.. meta::
+   :description: Provides the absolute path to the trusted X.509 CA certificate
+                 that signed the MongoDB server certificate.
+   :keywords: rsyslog, ommongodb, ssl ca, mongodb action parameter
+
 SSL_Ca
 ======
 
@@ -10,7 +15,8 @@ SSL_Ca
 
 .. summary-start
 
-Provides the absolute path to the trusted X.509 CA certificate that signed the MongoDB server certificate.
+Provides the absolute path to the trusted X.509 CA certificate that signed the
+MongoDB server certificate.
 
 .. summary-end
 

--- a/doc/source/reference/parameters/ommongodb-ssl-cert.rst
+++ b/doc/source/reference/parameters/ommongodb-ssl-cert.rst
@@ -1,6 +1,11 @@
 .. _param-ommongodb-ssl-cert:
 .. _ommongodb.parameter.input.ssl-cert:
 
+.. meta::
+   :description: Specifies the absolute path to the X.509 client certificate
+                 used for TLS authentication.
+   :keywords: rsyslog, ommongodb, ssl cert, mongodb action parameter
+
 SSL_Cert
 ========
 
@@ -10,7 +15,8 @@ SSL_Cert
 
 .. summary-start
 
-Specifies the absolute path to the X.509 client certificate for TLS authentication.
+Specifies the absolute path to the X.509 client certificate for TLS
+authentication.
 
 .. summary-end
 

--- a/doc/source/reference/parameters/ommongodb-ssl-cert.rst
+++ b/doc/source/reference/parameters/ommongodb-ssl-cert.rst
@@ -1,0 +1,46 @@
+.. _param-ommongodb-ssl-cert:
+.. _ommongodb.parameter.module.ssl-cert:
+
+SSL_Cert
+========
+
+.. index::
+   single: ommongodb; SSL_Cert
+   single: SSL_Cert
+
+.. summary-start
+
+Specifies the absolute path to the X.509 client certificate for TLS authentication.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/ommongodb`.
+
+:Name: SSL_Cert
+:Scope: module
+:Type: word
+:Default: module=none
+:Required?: no
+:Introduced: at least 7.x, possibly earlier
+
+Description
+-----------
+Absolute path to the X509 certificate you want to use for TLS client
+authentication. This is optional.
+
+Module usage
+------------
+.. _param-ommongodb-module-ssl-cert:
+.. _ommongodb.parameter.module.ssl-cert-usage:
+
+.. code-block:: rsyslog
+
+   module(load="ommongodb")
+   action(type="ommongodb"
+          uriStr="mongodb://vulture:9091/?ssl=true"
+          sslCert="/var/db/mongodb/mongod.pem"
+          db="logs" collection="syslog")
+
+See also
+--------
+See also :doc:`../../configuration/modules/ommongodb`.

--- a/doc/source/reference/parameters/ommongodb-ssl-cert.rst
+++ b/doc/source/reference/parameters/ommongodb-ssl-cert.rst
@@ -1,5 +1,5 @@
 .. _param-ommongodb-ssl-cert:
-.. _ommongodb.parameter.module.ssl-cert:
+.. _ommongodb.parameter.input.ssl-cert:
 
 SSL_Cert
 ========
@@ -17,9 +17,9 @@ Specifies the absolute path to the X.509 client certificate for TLS authenticati
 This parameter applies to :doc:`../../configuration/modules/ommongodb`.
 
 :Name: SSL_Cert
-:Scope: module
+:Scope: input
 :Type: word
-:Default: module=none
+:Default: input=none
 :Required?: no
 :Introduced: at least 7.x, possibly earlier
 
@@ -28,10 +28,10 @@ Description
 Absolute path to the X509 certificate you want to use for TLS client
 authentication. This is optional.
 
-Module usage
-------------
-.. _param-ommongodb-module-ssl-cert:
-.. _ommongodb.parameter.module.ssl-cert-usage:
+Input usage
+-----------
+.. _param-ommongodb-input-ssl-cert:
+.. _ommongodb.parameter.input.ssl-cert-usage:
 
 .. code-block:: rsyslog
 

--- a/doc/source/reference/parameters/ommongodb-template.rst
+++ b/doc/source/reference/parameters/ommongodb-template.rst
@@ -1,5 +1,5 @@
 .. _param-ommongodb-template:
-.. _ommongodb.parameter.module.template:
+.. _ommongodb.parameter.input.template:
 
 Template
 ========
@@ -17,9 +17,9 @@ Selects the rsyslog template used when formatting log records for MongoDB insert
 This parameter applies to :doc:`../../configuration/modules/ommongodb`.
 
 :Name: Template
-:Scope: module
+:Scope: input
 :Type: word
-:Default: module=OMSR_TPL_AS_MSG
+:Default: input=OMSR_TPL_AS_MSG
 :Required?: no
 :Introduced: at least 7.x, possibly earlier
 
@@ -52,10 +52,10 @@ to use a subset of the fields, but with lumberjack names, you can look up the
 mapping in the default template. For example, the lumberjack field "level"
 contains the rsyslog property "syslogpriority-text" rendered in uppercase.
 
-Module usage
-------------
-.. _param-ommongodb-module-template:
-.. _ommongodb.parameter.module.template-usage:
+Input usage
+-----------
+.. _param-ommongodb-input-template:
+.. _ommongodb.parameter.input.template-usage:
 
 .. code-block:: rsyslog
 

--- a/doc/source/reference/parameters/ommongodb-template.rst
+++ b/doc/source/reference/parameters/ommongodb-template.rst
@@ -40,13 +40,7 @@ is an example template that produces a document similar to the default:
 
 .. code-block:: none
 
-   template(name="BSON" type="string" string="{\"sys\" : \"%hostname%\", \
-   \"time\" : \"%timereported:::rfc3339%\", \"time_rcvd\" : \
-   \"%timegenerated:::rfc3339%\", \"msg\" : \"%msg%\", \
-   \"syslog_fac\" : \"%syslogfacility%\", \"syslog_sever\" : \
-   \"%syslogseverity%\", \"syslog_tag\" : \"%syslogtag%\", \
-   \"procid\" : \"%programname%\", \"pid\" : \"%procid%\", \
-   \"level\" : \"%syslogpriority-text:uppercase%\"}")
+   template(name="BSON" type="string" string="{\"sys\": \"%hostname%\", \"time\": \"%timereported:::rfc3339%\", \"time_rcvd\": \"%timegenerated:::rfc3339%\", \"msg\": \"%msg%\", \"syslog_fac\": \"%syslogfacility%\", \"syslog_server\": \"%syslogseverity%\", \"syslog_tag\": \"%syslogtag%\", \"procid\": \"%programname%\", \"pid\": \"%procid%\", \"level\": \"%syslogpriority-text:uppercase%\"}")
 
 This creates the BSON document needed for MongoDB if no template is specified.
 The default schema is aligned to CEE and project lumberjack. As such, the field

--- a/doc/source/reference/parameters/ommongodb-template.rst
+++ b/doc/source/reference/parameters/ommongodb-template.rst
@@ -33,13 +33,13 @@ is:
 
 .. code-block:: none
 
-   template(name="BSON" type="string" string="\"sys\" : \"%hostname%\", \
+   template(name="BSON" type="string" string="{\"sys\" : \"%hostname%\", \
    \"time\" : \"%timereported:::rfc3339%\", \"time_rcvd\" : \
    \"%timegenerated:::rfc3339%\", \"msg\" : \"%msg%\", \
-   \"syslog_fac\" : \"%syslogfacility%\", \"syslog_sever\" : \
+   \"syslog_fac\" : \"%syslogfacility%\", \"syslog_server\" : \
    \"%syslogseverity%\", \"syslog_tag\" : \"%syslogtag%\", \
    \"procid\" : \"%programname%\", \"pid\" : \"%procid%\", \
-   \"level\" : \"%syslogpriority-text:uppercase%\"")
+   \"level\" : \"%syslogpriority-text:uppercase%\"}")
 
 This creates the BSON document needed for MongoDB if no template is specified.
 The default schema is aligned to CEE and project lumberjack. As such, the field

--- a/doc/source/reference/parameters/ommongodb-template.rst
+++ b/doc/source/reference/parameters/ommongodb-template.rst
@@ -51,13 +51,12 @@ This creates the BSON document needed for MongoDB if no template is specified.
 The default schema is aligned to CEE and project lumberjack. As such, the field
 names are standard lumberjack field names, and **not** `rsyslog property names
 <property_replacer.html>`_. When specifying templates, be sure to use rsyslog
-property names as given in the table. If you would like to use lumberjack-based
-field names inside MongoDB (which probably is useful depending on the use
-case), you need to select fields names based on the lumberjack schema. If you
-just want to use a subset of the fields, but with lumberjack names, you can
-look up the mapping in the default template. For example, the lumberjack field
-"level" contains the rsyslog property "syslogpriority-text" rendered in
-uppercase.
+property names. If you would like to use lumberjack-based field names inside
+MongoDB (which probably is useful depending on the use case), you need to
+select fields names based on the lumberjack schema. If you just want to use a
+subset of the fields, but with lumberjack names, you can look up the mapping in
+the default template. For example, the lumberjack field "level" contains the
+rsyslog property "syslogpriority-text" rendered in uppercase.
 
 Input usage
 -----------

--- a/doc/source/reference/parameters/ommongodb-template.rst
+++ b/doc/source/reference/parameters/ommongodb-template.rst
@@ -33,13 +33,13 @@ is:
 
 .. code-block:: none
 
-   template(name="BSON" type="string" string="\"sys\" : \"%hostname%\"",
-   \"time\" : \"%timereported:::rfc3339%\", \"time_rcvd\" :
-   \"%timegenerated:::rfc3339%\", \"msg\" : \"%msg%\",
-   \"syslog_fac\" : \"%syslogfacility%\", \"syslog_server\" :
-   \"%syslogseverity%\", \"syslog_tag\" : \"%syslogtag%\",
-   \"procid\" : \"%programname%\", \"pid\" : \"%procid%\",
-   \"level\" : \"%syslogpriority-text%\"")
+   template(name="BSON" type="string" string="\"sys\" : \"%hostname%\", \
+   \"time\" : \"%timereported:::rfc3339%\", \"time_rcvd\" : \
+   \"%timegenerated:::rfc3339%\", \"msg\" : \"%msg%\", \
+   \"syslog_fac\" : \"%syslogfacility%\", \"syslog_sever\" : \
+   \"%syslogseverity%\", \"syslog_tag\" : \"%syslogtag%\", \
+   \"procid\" : \"%programname%\", \"pid\" : \"%procid%\", \
+   \"level\" : \"%syslogpriority-text:uppercase%\"")
 
 This creates the BSON document needed for MongoDB if no template is specified.
 The default schema is aligned to CEE and project lumberjack. As such, the field
@@ -50,7 +50,7 @@ field names inside MongoDB (which probably is useful depending on the use case),
 you need to select fields names based on the lumberjack schema. If you just want
 to use a subset of the fields, but with lumberjack names, you can look up the
 mapping in the default template. For example, the lumberjack field "level"
-contains the rsyslog property "syslogpriority-text".
+contains the rsyslog property "syslogpriority-text" rendered in uppercase.
 
 Module usage
 ------------

--- a/doc/source/reference/parameters/ommongodb-template.rst
+++ b/doc/source/reference/parameters/ommongodb-template.rst
@@ -1,0 +1,70 @@
+.. _param-ommongodb-template:
+.. _ommongodb.parameter.module.template:
+
+Template
+========
+
+.. index::
+   single: ommongodb; Template
+   single: Template
+
+.. summary-start
+
+Selects the rsyslog template used when formatting log records for MongoDB insertion.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/ommongodb`.
+
+:Name: Template
+:Scope: module
+:Type: word
+:Default: module=OMSR_TPL_AS_MSG
+:Required?: no
+:Introduced: at least 7.x, possibly earlier
+
+Description
+-----------
+Template to use when submitting messages.
+
+Note rsyslog contains a canned default template to write to the MongoDB. It will
+be used automatically if no other template is specified to be used. This template
+is:
+
+.. code-block:: none
+
+   template(name="BSON" type="string" string="\"sys\" : \"%hostname%\"",
+   \"time\" : \"%timereported:::rfc3339%\", \"time_rcvd\" :
+   \"%timegenerated:::rfc3339%\", \"msg\" : \"%msg%\",
+   \"syslog_fac\" : \"%syslogfacility%\", \"syslog_server\" :
+   \"%syslogseverity%\", \"syslog_tag\" : \"%syslogtag%\",
+   \"procid\" : \"%programname%\", \"pid\" : \"%procid%\",
+   \"level\" : \"%syslogpriority-text%\"")
+
+This creates the BSON document needed for MongoDB if no template is specified.
+The default schema is aligned to CEE and project lumberjack. As such, the field
+names are standard lumberjack field names, and **not** `rsyslog property names
+<property_replacer.html>`_. When specifying templates, be sure to use rsyslog
+property names as given in the table. If you would like to use lumberjack-based
+field names inside MongoDB (which probably is useful depending on the use case),
+you need to select fields names based on the lumberjack schema. If you just want
+to use a subset of the fields, but with lumberjack names, you can look up the
+mapping in the default template. For example, the lumberjack field "level"
+contains the rsyslog property "syslogpriority-text".
+
+Module usage
+------------
+.. _param-ommongodb-module-template:
+.. _ommongodb.parameter.module.template-usage:
+
+.. code-block:: rsyslog
+
+   module(load="ommongodb")
+   action(type="ommongodb"
+          uriStr="mongodb://vulture:9091/?ssl=true"
+          template="BSON"
+          db="syslog" collection="log")
+
+See also
+--------
+See also :doc:`../../configuration/modules/ommongodb`.

--- a/doc/source/reference/parameters/ommongodb-template.rst
+++ b/doc/source/reference/parameters/ommongodb-template.rst
@@ -33,16 +33,17 @@ Description
 -----------
 Template to use when submitting messages.
 
-Note rsyslog contains a canned default template to write to the MongoDB. It will
-be used automatically if no other template is specified to be used. This
-template is:
+Note that if no template is specified, rsyslog generates a default BSON
+document with a structure aligned to CEE and project lumberjack. If you need to
+customize the document format, you can define your own template. The following
+is an example template that produces a document similar to the default:
 
 .. code-block:: none
 
    template(name="BSON" type="string" string="{\"sys\" : \"%hostname%\", \
    \"time\" : \"%timereported:::rfc3339%\", \"time_rcvd\" : \
    \"%timegenerated:::rfc3339%\", \"msg\" : \"%msg%\", \
-   \"syslog_fac\" : \"%syslogfacility%\", \"syslog_server\" : \
+   \"syslog_fac\" : \"%syslogfacility%\", \"syslog_sever\" : \
    \"%syslogseverity%\", \"syslog_tag\" : \"%syslogtag%\", \
    \"procid\" : \"%programname%\", \"pid\" : \"%procid%\", \
    \"level\" : \"%syslogpriority-text:uppercase%\"}")

--- a/doc/source/reference/parameters/ommongodb-template.rst
+++ b/doc/source/reference/parameters/ommongodb-template.rst
@@ -1,6 +1,11 @@
 .. _param-ommongodb-template:
 .. _ommongodb.parameter.input.template:
 
+.. meta::
+   :description: Selects the rsyslog template used when formatting log records
+                 for MongoDB insertion.
+   :keywords: rsyslog, ommongodb, template, mongodb action parameter
+
 Template
 ========
 
@@ -10,7 +15,8 @@ Template
 
 .. summary-start
 
-Selects the rsyslog template used when formatting log records for MongoDB insertion.
+Selects the rsyslog template used when formatting log records for MongoDB
+insertion.
 
 .. summary-end
 
@@ -28,8 +34,8 @@ Description
 Template to use when submitting messages.
 
 Note rsyslog contains a canned default template to write to the MongoDB. It will
-be used automatically if no other template is specified to be used. This template
-is:
+be used automatically if no other template is specified to be used. This
+template is:
 
 .. code-block:: none
 
@@ -46,11 +52,12 @@ The default schema is aligned to CEE and project lumberjack. As such, the field
 names are standard lumberjack field names, and **not** `rsyslog property names
 <property_replacer.html>`_. When specifying templates, be sure to use rsyslog
 property names as given in the table. If you would like to use lumberjack-based
-field names inside MongoDB (which probably is useful depending on the use case),
-you need to select fields names based on the lumberjack schema. If you just want
-to use a subset of the fields, but with lumberjack names, you can look up the
-mapping in the default template. For example, the lumberjack field "level"
-contains the rsyslog property "syslogpriority-text" rendered in uppercase.
+field names inside MongoDB (which probably is useful depending on the use
+case), you need to select fields names based on the lumberjack schema. If you
+just want to use a subset of the fields, but with lumberjack names, you can
+look up the mapping in the default template. For example, the lumberjack field
+"level" contains the rsyslog property "syslogpriority-text" rendered in
+uppercase.
 
 Input usage
 -----------

--- a/doc/source/reference/parameters/ommongodb-uid.rst
+++ b/doc/source/reference/parameters/ommongodb-uid.rst
@@ -1,6 +1,11 @@
 .. _param-ommongodb-uid:
 .. _ommongodb.parameter.input.uid:
 
+.. meta::
+   :description: Sets the login user ID for MongoDB authentication; deprecated
+                 in favor of credentials in ``UriStr``.
+   :keywords: rsyslog, ommongodb, user id, mongodb action parameter
+
 UID
 ===
 
@@ -10,7 +15,8 @@ UID
 
 .. summary-start
 
-Sets the login user ID for MongoDB authentication (deprecated; prefer ``UriStr`` credentials).
+Sets the login user ID for MongoDB authentication (deprecated; prefer
+``UriStr`` credentials).
 
 .. summary-end
 

--- a/doc/source/reference/parameters/ommongodb-uid.rst
+++ b/doc/source/reference/parameters/ommongodb-uid.rst
@@ -1,5 +1,5 @@
 .. _param-ommongodb-uid:
-.. _ommongodb.parameter.module.uid:
+.. _ommongodb.parameter.input.uid:
 
 UID
 ===
@@ -17,9 +17,9 @@ Sets the login user ID for MongoDB authentication (deprecated; prefer ``UriStr``
 This parameter applies to :doc:`../../configuration/modules/ommongodb`.
 
 :Name: UID
-:Scope: module
+:Scope: input
 :Type: word
-:Default: module=none
+:Default: input=none
 :Required?: no
 :Introduced: at least 7.x, possibly earlier
 
@@ -28,10 +28,10 @@ Description
 Logon userid used to connect to server. Must have proper permissions. This
 parameter is deprecated and should not be used for new configurations.
 
-Module usage
-------------
-.. _param-ommongodb-module-uid:
-.. _ommongodb.parameter.module.uid-usage:
+Input usage
+-----------
+.. _param-ommongodb-input-uid:
+.. _ommongodb.parameter.input.uid-usage:
 
 .. code-block:: rsyslog
 

--- a/doc/source/reference/parameters/ommongodb-uid.rst
+++ b/doc/source/reference/parameters/ommongodb-uid.rst
@@ -1,0 +1,45 @@
+.. _param-ommongodb-uid:
+.. _ommongodb.parameter.module.uid:
+
+UID
+===
+
+.. index::
+   single: ommongodb; UID
+   single: UID
+
+.. summary-start
+
+Sets the login user ID for MongoDB authentication (deprecated; prefer ``UriStr`` credentials).
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/ommongodb`.
+
+:Name: UID
+:Scope: module
+:Type: word
+:Default: module=none
+:Required?: no
+:Introduced: at least 7.x, possibly earlier
+
+Description
+-----------
+Logon userid used to connect to server. Must have proper permissions. This
+parameter is deprecated and should not be used for new configurations.
+
+Module usage
+------------
+.. _param-ommongodb-module-uid:
+.. _ommongodb.parameter.module.uid-usage:
+
+.. code-block:: rsyslog
+
+   module(load="ommongodb")
+   action(type="ommongodb"
+          server="mongoserver.example.com" db="syslog" collection="log"
+          uid="user" pwd="pwd")
+
+See also
+--------
+See also :doc:`../../configuration/modules/ommongodb`.

--- a/doc/source/reference/parameters/ommongodb-uristr.rst
+++ b/doc/source/reference/parameters/ommongodb-uristr.rst
@@ -1,5 +1,5 @@
 .. _param-ommongodb-uristr:
-.. _ommongodb.parameter.module.uristr:
+.. _ommongodb.parameter.input.uristr:
 
 UriStr
 ======
@@ -17,23 +17,22 @@ Sets the MongoDB connection string to use instead of individual server, port, an
 This parameter applies to :doc:`../../configuration/modules/ommongodb`.
 
 :Name: UriStr
-:Scope: module
+:Scope: input
 :Type: word
-:Default: module=none
+:Default: input=none
 :Required?: no
 :Introduced: at least 7.x, possibly earlier
 
 Description
 -----------
-MongoDB connection string, as defined by the MongoDB String URI Format (see
-<https://docs.mongodb.com/manual/reference/connection-string/>). If ``UriStr`` is
+MongoDB connection string, as defined by the `MongoDB String URI Format <https://docs.mongodb.com/manual/reference/connection-string/>`_. If ``UriStr`` is
 set, the legacy ``Server``, ``ServerPorted``, ``UID``, and ``PWD`` directives are
 ignored.
 
-Module usage
-------------
-.. _param-ommongodb-module-uristr:
-.. _ommongodb.parameter.module.uristr-usage:
+Input usage
+-----------
+.. _param-ommongodb-input-uristr:
+.. _ommongodb.parameter.input.uristr-usage:
 
 .. code-block:: rsyslog
 

--- a/doc/source/reference/parameters/ommongodb-uristr.rst
+++ b/doc/source/reference/parameters/ommongodb-uristr.rst
@@ -1,6 +1,11 @@
 .. _param-ommongodb-uristr:
 .. _ommongodb.parameter.input.uristr:
 
+.. meta::
+   :description: Sets the MongoDB connection string to replace separate server,
+                 port, and credential parameters.
+   :keywords: rsyslog, ommongodb, UriStr, mongodb action parameter
+
 UriStr
 ======
 
@@ -10,7 +15,8 @@ UriStr
 
 .. summary-start
 
-Sets the MongoDB connection string to use instead of individual server, port, and credential parameters.
+Sets the MongoDB connection string to use instead of individual server, port,
+and credential parameters.
 
 .. summary-end
 
@@ -25,9 +31,10 @@ This parameter applies to :doc:`../../configuration/modules/ommongodb`.
 
 Description
 -----------
-MongoDB connection string, as defined by the `MongoDB String URI Format <https://docs.mongodb.com/manual/reference/connection-string/>`_. If ``UriStr`` is
-set, the legacy ``Server``, ``ServerPorted``, ``UID``, and ``PWD`` directives are
-ignored.
+MongoDB connection string, as defined by the `MongoDB String URI Format
+<https://docs.mongodb.com/manual/reference/connection-string/>`_. If ``UriStr``
+is set, the legacy ``Server``, ``ServerPorted``, ``UID``, and ``PWD``
+directives are ignored.
 
 Input usage
 -----------
@@ -38,7 +45,7 @@ Input usage
 
    module(load="ommongodb")
    action(type="ommongodb"
-          uriStr="mongodb://vulture:9091,vulture2:9091/?replicaset=Vulture&ssl=true"
+          uriStr="mongodb://v1:9091,v2:9091/?replicaset=Vulture&ssl=true"
           db="logs" collection="syslog")
 
 See also

--- a/doc/source/reference/parameters/ommongodb-uristr.rst
+++ b/doc/source/reference/parameters/ommongodb-uristr.rst
@@ -26,7 +26,7 @@ This parameter applies to :doc:`../../configuration/modules/ommongodb`.
 Description
 -----------
 MongoDB connection string, as defined by the MongoDB String URI Format (see
-https://docs.mongodb.com/manual/reference/connection-string/). If ``UriStr`` is
+<https://docs.mongodb.com/manual/reference/connection-string/>). If ``UriStr`` is
 set, the legacy ``Server``, ``ServerPorted``, ``UID``, and ``PWD`` directives are
 ignored.
 

--- a/doc/source/reference/parameters/ommongodb-uristr.rst
+++ b/doc/source/reference/parameters/ommongodb-uristr.rst
@@ -1,0 +1,47 @@
+.. _param-ommongodb-uristr:
+.. _ommongodb.parameter.module.uristr:
+
+UriStr
+======
+
+.. index::
+   single: ommongodb; UriStr
+   single: UriStr
+
+.. summary-start
+
+Sets the MongoDB connection string to use instead of individual server, port, and credential parameters.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/ommongodb`.
+
+:Name: UriStr
+:Scope: module
+:Type: word
+:Default: module=none
+:Required?: no
+:Introduced: at least 7.x, possibly earlier
+
+Description
+-----------
+MongoDB connection string, as defined by the MongoDB String URI Format (see
+https://docs.mongodb.com/manual/reference/connection-string/). If ``UriStr`` is
+set, the legacy ``Server``, ``ServerPorted``, ``UID``, and ``PWD`` directives are
+ignored.
+
+Module usage
+------------
+.. _param-ommongodb-module-uristr:
+.. _ommongodb.parameter.module.uristr-usage:
+
+.. code-block:: rsyslog
+
+   module(load="ommongodb")
+   action(type="ommongodb"
+          uriStr="mongodb://vulture:9091,vulture2:9091/?replicaset=Vulture&ssl=true"
+          db="logs" collection="syslog")
+
+See also
+--------
+See also :doc:`../../configuration/modules/ommongodb`.


### PR DESCRIPTION
## Summary
- add per-parameter reference pages for ommongodb action and deprecated parameters with stable anchors and usage examples
- replace inline parameter documentation with summary list-tables and a hidden toctree while preserving existing examples

## Testing
- not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c2ee7c9d483308be5b4117fca7e9c)