### PR TITLE
omrelp: split parameter docs into reference pages

### DIFF
--- a/doc/source/configuration/modules/omrelp.rst
+++ b/doc/source/configuration/modules/omrelp.rst
@@ -26,468 +26,141 @@ Configuration Parameters
 
 .. note::
 
-   Parameter names are case-insensitive.
+   Parameter names are case-insensitive; camelCase is recommended for readability.
 
 Module Parameters
 -----------------
 
-tls.tlslib
-^^^^^^^^^^
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
 
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "none", "no", "none"
-
-.. versionadded:: 8.1903.0
-
-Permits to specify the TLS library used by librelp.
-All relp protocol operations or actually performed by librelp and
-not rsyslog itself.  This value specified is directly passed down to
-librelp. Depending on librelp version and build parameters, supported
-tls libraries differ (or TLS may not be supported at all). In this case
-rsyslog emits an error message.
-
-Usually, the following options should be available: "openssl", "gnutls".
-
-Note that "gnutls" is the current default for historic reasons. We actually
-recommend to use "openssl". It provides better error messages and accepts
-a wider range of certificate types.
-
-If you have problems with the default setting, we recommend to switch to
-"openssl".
-
+   * - Parameter
+     - Summary
+   * - :ref:`param-omrelp-tls-tlslib`
+     - .. include:: ../../reference/parameters/omrelp-tls-tlslib.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
 
 Action Parameters
 -----------------
 
-Target
-^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "none", "yes", "none"
-
-The target server to connect to.
-
-
-Port
-^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "514", "no", "none"
-
-Name or numerical value of TCP port to use when connecting to target.
-
-
-Template
-^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "RSYSLOG_ForwardFormat", "no", "none"
-
-Defines the template to be used for the output.
-
-
-Timeout
-^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "int", "90", "no", "none"
-
-Timeout for relp sessions. If set too low, valid sessions may be
-considered dead and tried to recover.
-
-
-Conn.Timeout
-^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "int", "10", "no", "none"
-
-Timeout for the socket connection.
-
-
-RebindInterval
-^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "int", "0", "no", "none"
-
-Permits to specify an interval at which the current connection is
-broken and re-established. This setting is primarily an aid to load
-balancers. After the configured number of messages has been
-transmitted, the current connection is terminated and a new one
-started. This usually is perceived as a \`\`new connection'' by load
-balancers, which in turn forward messages to another physical target
-system.
-
-
-KeepAlive
-^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none"
-
-Enable or disable keep-alive packets at the TCP socket layer. By
-default keep-alive is disabled.
-
-
-KeepAlive.Probes
-^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "0", "no", "none"
-
-The number of keepalive probes to send before considering the
-connection dead. The default, 0, uses the operating system defaults.
-This only has an effect if keep-alive is enabled and may not be
-available on all platforms.
-
-
-KeepAlive.Interval
-^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "0", "no", "none"
-
-The interval between subsequent keepalive probes. The default, 0,
-uses the operating system defaults. This only has an effect if
-keep-alive is enabled and may not be available on all platforms.
-
-
-KeepAlive.Time
-^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "0", "no", "none"
-
-The idle time before the first keepalive probe is sent. The default, 0,
-uses the operating system defaults. This only has an effect if
-keep-alive is enabled and may not be available on all platforms.
-
-
-WindowSize
-^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "int", "0", "no", "none"
-
-This is an **expert parameter**. It permits to override the RELP
-window size being used by the client. Changing the window size has
-both an effect on performance as well as potential message
-duplication in failure case. A larger window size means more
-performance, but also potentially more duplicated messages - and vice
-versa. The default 0 means that librelp's default window size is
-being used, which is considered a compromise between goals reached.
-For your information: at the time of this writing, the librelp
-default window size is 128 messages, but this may change at any time.
-Note that there is no equivalent server parameter, as the client
-proposes and manages the window size in RELP protocol.
-
-
-TLS
-^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none"
-
-If set to "on", the RELP connection will be encrypted by TLS, so
-that the data is protected against observers. Please note that both
-the client and the server must have set TLS to either "on" or "off".
-Other combinations lead to unpredictable results.
-
-*Attention when using GnuTLS 2.10.x or older*
-
-Versions older than GnuTLS 2.10.x may cause a crash (Segfault) under
-certain circumstances. Most likely when an imrelp inputs and an
-omrelp output is configured. The crash may happen when you are
-receiving/sending messages at the same time. Upgrade to a newer
-version like GnuTLS 2.12.21 to solve the problem.
-
-
-TLS.Compression
-^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none"
-
-The controls if the TLS stream should be compressed (zipped). While
-this increases CPU use, the network bandwidth should be reduced. Note
-that typical text-based log records usually compress rather well.
-
-
-TLS.PermittedPeer
-^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "array", "none", "no", "none"
-
-Note: this parameter is mandatory depending on the value of
-`TLS.AuthMode` but the code does currently not check this.
-
-Peer Places access restrictions on this forwarder. Only peers which
-have been listed in this parameter may be connected to. This guards
-against rogue servers and man-in-the-middle attacks. The validation
-bases on the certificate the remote peer presents.
-
-This contains either remote system names or fingerprints, depending
-on the value of parameter `TLS.AuthMode`. One or more values may be
-entered.
-
-When a non-permitted peer is connected to, the refusal is logged
-together with the given remote peer identify. This is especially
-useful in *fingerprint* authentication mode: if the
-administrator knows this was a valid request, he can simply add the
-fingerprint by copy and paste from the logfile to rsyslog.conf. It
-must be noted, though, that this situation should usually not happen
-after initial client setup and administrators should be alert in this
-case.
-
-Note that usually a single remote peer should be all that is ever
-needed. Support for multiple peers is primarily included in support
-of load balancing scenarios. If the connection goes to a specific
-server, only one specific certificate is ever expected (just like
-when connecting to a specific ssh server).
-To specify multiple fingerprints, just enclose them in braces like
-this:
-
-.. code-block:: none
-
-   tls.permittedPeer=["SHA1:...1", "SHA1:....2"]
-
-To specify just a single peer, you can either specify the string
-directly or enclose it in braces.
-
-Note that in *name* authentication mode wildcards are supported.
-This can be done as follows:
-
-.. code-block:: none
-
-   tls.permittedPeer="*.example.com"
-
-Of course, there can also be multiple names used, some with and
-some without wildcards:
-
-.. code-block:: none
-
-   tls.permittedPeer=["*.example.com", "srv1.example.net", "srv2.example.net"]
-
-
-TLS.AuthMode
-^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "none", "no", "none"
-
-Sets the mode used for mutual authentication. Supported values are
-either "*fingerprint*" or "*name*". Fingerprint mode basically is
-what SSH does. It does not require a full PKI to be present, instead
-self-signed certs can be used on all peers. Even if a CA certificate
-is given, the validity of the peer cert is NOT verified against it.
-Only the certificate fingerprint counts.
-
-In "name" mode, certificate validation happens. Here, the matching is
-done against the certificate's subjectAltName and, as a fallback, the
-subject common name. If the certificate contains multiple names, a
-match on any one of these names is considered good and permits the
-peer to talk to rsyslog.
-
-The permitted names or fingerprints are configured via
-`TLS.PermittedPeer`.
-
-
-About Chained Certificates
---------------------------
-
-.. versionadded:: 8.2008.0
-
-With librelp 1.7.0, you can use chained certificates.
-If using "openssl" as tls.tlslib, we recommend at least OpenSSL Version 1.1
-or higher. Chained certificates will also work with OpenSSL Version 1.0.2, but
-they will be loaded into the main OpenSSL context object making them available
-to all librelp instances (omrelp/imrelp) within the same process.
-
-If this is not desired, you will require to run rsyslog in multiple instances
-with different omrelp configurations and certificates.
-
-
-TLS.CaCert
-^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "none", "no", "none"
-
-The CA certificate that can verify the machine certs.
-
-
-TLS.MyCert
-^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "none", "no", "none"
-
-The machine public certificate.
-
-
-TLS.MyPrivKey
-^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "none", "no", "none"
-
-The machine private key.
-
-
-TLS.PriorityString
-^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "none", "no", "none"
-
-This parameter permits to specify the so-called "priority string" to
-GnuTLS. This string gives complete control over all crypto
-parameters, including compression setting. For this reason, when the
-prioritystring is specified, the "tls.compression" parameter has no
-effect and is ignored.
-Full information about how to construct a priority string can be
-found in the GnuTLS manual. At the time of this writing, this
-information was contained in `section 6.10 of the GnuTLS
-manual <http://gnutls.org/manual/html_node/Priority-Strings.html>`__.
-**Note: this is an expert parameter.** Do not use if you do not
-exactly know what you are doing.
-
-tls.tlscfgcmd
-^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "none", "no", "none"
-
-.. versionadded:: 8.2001.0
-
-The setting can be used if tls.tlslib is set to "openssl" to pass configuration commands to
-the openssl library.
-OpenSSL Version 1.0.2 or higher is required for this feature.
-A list of possible commands and their valid values can be found in the documentation:
-https://docs.openssl.org/1.0.2/man3/SSL_CONF_cmd/
-
-The setting can be single or multiline, each configuration command is separated by linefeed (\n).
-Command and value are separated by equal sign (=). Here are a few samples:
-
-Example 1
----------
-
-This will allow all protocols except for SSLv2 and SSLv3:
-
-.. code-block:: none
-
-   tls.tlscfgcmd="Protocol=ALL,-SSLv2,-SSLv3"
-
-
-Example 2
----------
-
-This will allow all protocols except for SSLv2, SSLv3 and TLSv1.
-It will also set the minimum protocol to TLSv1.2
-
-.. code-block:: none
-
-   tls.tlscfgcmd="Protocol=ALL,-SSLv2,-SSLv3,-TLSv1
-   MinProtocol=TLSv1.2"
-
-LocalClientIp
-^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "none", "no", "none"
-
-Omrelp uses ip_address as local client address while connecting
-to remote logserver.
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Parameter
+     - Summary
+   * - :ref:`param-omrelp-target`
+     - .. include:: ../../reference/parameters/omrelp-target.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omrelp-port`
+     - .. include:: ../../reference/parameters/omrelp-port.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omrelp-template`
+     - .. include:: ../../reference/parameters/omrelp-template.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omrelp-timeout`
+     - .. include:: ../../reference/parameters/omrelp-timeout.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omrelp-conn-timeout`
+     - .. include:: ../../reference/parameters/omrelp-conn-timeout.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omrelp-rebindinterval`
+     - .. include:: ../../reference/parameters/omrelp-rebindinterval.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omrelp-keepalive`
+     - .. include:: ../../reference/parameters/omrelp-keepalive.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omrelp-keepalive-probes`
+     - .. include:: ../../reference/parameters/omrelp-keepalive-probes.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omrelp-keepalive-interval`
+     - .. include:: ../../reference/parameters/omrelp-keepalive-interval.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omrelp-keepalive-time`
+     - .. include:: ../../reference/parameters/omrelp-keepalive-time.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omrelp-windowsize`
+     - .. include:: ../../reference/parameters/omrelp-windowsize.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omrelp-tls`
+     - .. include:: ../../reference/parameters/omrelp-tls.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omrelp-tls-compression`
+     - .. include:: ../../reference/parameters/omrelp-tls-compression.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omrelp-tls-permittedpeer`
+     - .. include:: ../../reference/parameters/omrelp-tls-permittedpeer.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omrelp-tls-authmode`
+     - .. include:: ../../reference/parameters/omrelp-tls-authmode.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omrelp-tls-cacert`
+     - .. include:: ../../reference/parameters/omrelp-tls-cacert.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omrelp-tls-mycert`
+     - .. include:: ../../reference/parameters/omrelp-tls-mycert.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omrelp-tls-myprivkey`
+     - .. include:: ../../reference/parameters/omrelp-tls-myprivkey.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omrelp-tls-prioritystring`
+     - .. include:: ../../reference/parameters/omrelp-tls-prioritystring.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omrelp-tls-tlscfgcmd`
+     - .. include:: ../../reference/parameters/omrelp-tls-tlscfgcmd.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omrelp-localclientip`
+     - .. include:: ../../reference/parameters/omrelp-localclientip.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+.. toctree::
+   :hidden:
+
+   ../../reference/parameters/omrelp-tls-tlslib
+   ../../reference/parameters/omrelp-target
+   ../../reference/parameters/omrelp-port
+   ../../reference/parameters/omrelp-template
+   ../../reference/parameters/omrelp-timeout
+   ../../reference/parameters/omrelp-conn-timeout
+   ../../reference/parameters/omrelp-rebindinterval
+   ../../reference/parameters/omrelp-keepalive
+   ../../reference/parameters/omrelp-keepalive-probes
+   ../../reference/parameters/omrelp-keepalive-interval
+   ../../reference/parameters/omrelp-keepalive-time
+   ../../reference/parameters/omrelp-windowsize
+   ../../reference/parameters/omrelp-tls
+   ../../reference/parameters/omrelp-tls-compression
+   ../../reference/parameters/omrelp-tls-permittedpeer
+   ../../reference/parameters/omrelp-tls-authmode
+   ../../reference/parameters/omrelp-tls-cacert
+   ../../reference/parameters/omrelp-tls-mycert
+   ../../reference/parameters/omrelp-tls-myprivkey
+   ../../reference/parameters/omrelp-tls-prioritystring
+   ../../reference/parameters/omrelp-tls-tlscfgcmd
+   ../../reference/parameters/omrelp-localclientip
 
 
 Examples

--- a/doc/source/reference/parameters/omrelp-conn-timeout.rst
+++ b/doc/source/reference/parameters/omrelp-conn-timeout.rst
@@ -34,7 +34,7 @@ Input usage
 
 .. code-block:: rsyslog
 
-   action(type="omrelp" target="centralserv" conn.timeout="10")
+   action(type="omrelp" target="centralserv" connTimeout="10")
 
 See also
 --------

--- a/doc/source/reference/parameters/omrelp-conn-timeout.rst
+++ b/doc/source/reference/parameters/omrelp-conn-timeout.rst
@@ -1,0 +1,41 @@
+.. _param-omrelp-conn-timeout:
+.. _omrelp.parameter.input.conn-timeout:
+
+Conn.Timeout
+============
+
+.. index::
+   single: omrelp; Conn.Timeout
+   single: Conn.Timeout
+
+.. summary-start
+
+Controls how long the socket connection attempt is allowed to take.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omrelp`.
+
+:Name: Conn.Timeout
+:Scope: input
+:Type: integer
+:Default: input=10
+:Required?: no
+:Introduced: at least 7.0.0, possibly earlier
+
+Description
+-----------
+Timeout for the socket connection.
+
+Input usage
+-----------
+.. _param-omrelp-input-conn-timeout:
+.. _omrelp.parameter.input.conn-timeout-usage:
+
+.. code-block:: rsyslog
+
+   action(type="omrelp" target="centralserv" conn.timeout="10")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omrelp`.

--- a/doc/source/reference/parameters/omrelp-keepalive-interval.rst
+++ b/doc/source/reference/parameters/omrelp-keepalive-interval.rst
@@ -34,7 +34,7 @@ Input usage
 
 .. code-block:: rsyslog
 
-   action(type="omrelp" target="centralserv" keepAlive.interval="30")
+   action(type="omrelp" target="centralserv" keepAliveInterval="30")
 
 See also
 --------

--- a/doc/source/reference/parameters/omrelp-keepalive-interval.rst
+++ b/doc/source/reference/parameters/omrelp-keepalive-interval.rst
@@ -1,0 +1,41 @@
+.. _param-omrelp-keepalive-interval:
+.. _omrelp.parameter.input.keepalive-interval:
+
+KeepAlive.Interval
+==================
+
+.. index::
+   single: omrelp; KeepAlive.Interval
+   single: KeepAlive.Interval
+
+.. summary-start
+
+Configures the time between successive TCP keepalive probes.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omrelp`.
+
+:Name: KeepAlive.Interval
+:Scope: input
+:Type: integer
+:Default: input=0
+:Required?: no
+:Introduced: at least 7.0.0, possibly earlier
+
+Description
+-----------
+The interval between subsequent keepalive probes. The default, 0, uses the operating system defaults. This only has an effect if keep-alive is enabled and may not be available on all platforms.
+
+Input usage
+-----------
+.. _param-omrelp-input-keepalive-interval:
+.. _omrelp.parameter.input.keepalive-interval-usage:
+
+.. code-block:: rsyslog
+
+   action(type="omrelp" target="centralserv" keepAlive.interval="30")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omrelp`.

--- a/doc/source/reference/parameters/omrelp-keepalive-probes.rst
+++ b/doc/source/reference/parameters/omrelp-keepalive-probes.rst
@@ -1,0 +1,41 @@
+.. _param-omrelp-keepalive-probes:
+.. _omrelp.parameter.input.keepalive-probes:
+
+KeepAlive.Probes
+================
+
+.. index::
+   single: omrelp; KeepAlive.Probes
+   single: KeepAlive.Probes
+
+.. summary-start
+
+Sets how many keepalive probes are sent before a connection is deemed dead.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omrelp`.
+
+:Name: KeepAlive.Probes
+:Scope: input
+:Type: integer
+:Default: input=0
+:Required?: no
+:Introduced: at least 7.0.0, possibly earlier
+
+Description
+-----------
+The number of keepalive probes to send before considering the connection dead. The default, 0, uses the operating system defaults. This only has an effect if keep-alive is enabled and may not be available on all platforms.
+
+Input usage
+-----------
+.. _param-omrelp-input-keepalive-probes:
+.. _omrelp.parameter.input.keepalive-probes-usage:
+
+.. code-block:: rsyslog
+
+   action(type="omrelp" target="centralserv" keepAlive.probes="5")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omrelp`.

--- a/doc/source/reference/parameters/omrelp-keepalive-probes.rst
+++ b/doc/source/reference/parameters/omrelp-keepalive-probes.rst
@@ -34,7 +34,7 @@ Input usage
 
 .. code-block:: rsyslog
 
-   action(type="omrelp" target="centralserv" keepAlive.probes="5")
+   action(type="omrelp" target="centralserv" keepAliveProbes="5")
 
 See also
 --------

--- a/doc/source/reference/parameters/omrelp-keepalive-time.rst
+++ b/doc/source/reference/parameters/omrelp-keepalive-time.rst
@@ -34,7 +34,7 @@ Input usage
 
 .. code-block:: rsyslog
 
-   action(type="omrelp" target="centralserv" keepAlive.time="300")
+   action(type="omrelp" target="centralserv" keepAliveTime="300")
 
 See also
 --------

--- a/doc/source/reference/parameters/omrelp-keepalive-time.rst
+++ b/doc/source/reference/parameters/omrelp-keepalive-time.rst
@@ -1,0 +1,41 @@
+.. _param-omrelp-keepalive-time:
+.. _omrelp.parameter.input.keepalive-time:
+
+KeepAlive.Time
+==============
+
+.. index::
+   single: omrelp; KeepAlive.Time
+   single: KeepAlive.Time
+
+.. summary-start
+
+Specifies the idle time before the first TCP keepalive probe is sent.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omrelp`.
+
+:Name: KeepAlive.Time
+:Scope: input
+:Type: integer
+:Default: input=0
+:Required?: no
+:Introduced: at least 7.0.0, possibly earlier
+
+Description
+-----------
+The idle time before the first keepalive probe is sent. The default, 0, uses the operating system defaults. This only has an effect if keep-alive is enabled and may not be available on all platforms.
+
+Input usage
+-----------
+.. _param-omrelp-input-keepalive-time:
+.. _omrelp.parameter.input.keepalive-time-usage:
+
+.. code-block:: rsyslog
+
+   action(type="omrelp" target="centralserv" keepAlive.time="300")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omrelp`.

--- a/doc/source/reference/parameters/omrelp-keepalive.rst
+++ b/doc/source/reference/parameters/omrelp-keepalive.rst
@@ -1,0 +1,41 @@
+.. _param-omrelp-keepalive:
+.. _omrelp.parameter.input.keepalive:
+
+KeepAlive
+=========
+
+.. index::
+   single: omrelp; KeepAlive
+   single: KeepAlive
+
+.. summary-start
+
+Enables or disables TCP keep-alive packets for the RELP connection.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omrelp`.
+
+:Name: KeepAlive
+:Scope: input
+:Type: boolean
+:Default: input=off
+:Required?: no
+:Introduced: at least 7.0.0, possibly earlier
+
+Description
+-----------
+Enable or disable keep-alive packets at the TCP socket layer. By default keep-alive is disabled.
+
+Input usage
+-----------
+.. _param-omrelp-input-keepalive:
+.. _omrelp.parameter.input.keepalive-usage:
+
+.. code-block:: rsyslog
+
+   action(type="omrelp" target="centralserv" keepAlive="on")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omrelp`.

--- a/doc/source/reference/parameters/omrelp-localclientip.rst
+++ b/doc/source/reference/parameters/omrelp-localclientip.rst
@@ -1,0 +1,41 @@
+.. _param-omrelp-localclientip:
+.. _omrelp.parameter.input.localclientip:
+
+LocalClientIp
+=============
+
+.. index::
+   single: omrelp; LocalClientIp
+   single: LocalClientIp
+
+.. summary-start
+
+Sets the local client IP address used when connecting to the remote log server.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omrelp`.
+
+:Name: LocalClientIp
+:Scope: input
+:Type: string
+:Default: input=none
+:Required?: no
+:Introduced: at least 7.0.0, possibly earlier
+
+Description
+-----------
+Omrelp uses ip_address as local client address while connecting to remote logserver.
+
+Input usage
+-----------
+.. _param-omrelp-input-localclientip:
+.. _omrelp.parameter.input.localclientip-usage:
+
+.. code-block:: rsyslog
+
+   action(type="omrelp" target="centralserv" localClientIp="192.0.2.10")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omrelp`.

--- a/doc/source/reference/parameters/omrelp-port.rst
+++ b/doc/source/reference/parameters/omrelp-port.rst
@@ -1,0 +1,41 @@
+.. _param-omrelp-port:
+.. _omrelp.parameter.input.port:
+
+Port
+====
+
+.. index::
+   single: omrelp; Port
+   single: Port
+
+.. summary-start
+
+Specifies the TCP port number or service name for the RELP connection.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omrelp`.
+
+:Name: Port
+:Scope: input
+:Type: string
+:Default: input=514
+:Required?: no
+:Introduced: at least 7.0.0, possibly earlier
+
+Description
+-----------
+Name or numerical value of TCP port to use when connecting to target.
+
+Input usage
+-----------
+.. _param-omrelp-input-port:
+.. _omrelp.parameter.input.port-usage:
+
+.. code-block:: rsyslog
+
+   action(type="omrelp" target="centralserv" port="2514")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omrelp`.

--- a/doc/source/reference/parameters/omrelp-rebindinterval.rst
+++ b/doc/source/reference/parameters/omrelp-rebindinterval.rst
@@ -1,0 +1,41 @@
+.. _param-omrelp-rebindinterval:
+.. _omrelp.parameter.input.rebindinterval:
+
+RebindInterval
+==============
+
+.. index::
+   single: omrelp; RebindInterval
+   single: RebindInterval
+
+.. summary-start
+
+Forces periodic reconnection after a configured number of transmitted messages.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omrelp`.
+
+:Name: RebindInterval
+:Scope: input
+:Type: integer
+:Default: input=0
+:Required?: no
+:Introduced: at least 7.0.0, possibly earlier
+
+Description
+-----------
+Permits to specify an interval at which the current connection is broken and re-established. This setting is primarily an aid to load balancers. After the configured number of messages has been transmitted, the current connection is terminated and a new one started. This usually is perceived as a ``new connection'' by load balancers, which in turn forward messages to another physical target system.
+
+Input usage
+-----------
+.. _param-omrelp-input-rebindinterval:
+.. _omrelp.parameter.input.rebindinterval-usage:
+
+.. code-block:: rsyslog
+
+   action(type="omrelp" target="centralserv" rebindInterval="10000")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omrelp`.

--- a/doc/source/reference/parameters/omrelp-target.rst
+++ b/doc/source/reference/parameters/omrelp-target.rst
@@ -1,0 +1,41 @@
+.. _param-omrelp-target:
+.. _omrelp.parameter.input.target:
+
+Target
+======
+
+.. index::
+   single: omrelp; Target
+   single: Target
+
+.. summary-start
+
+Defines the remote server omrelp connects to.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omrelp`.
+
+:Name: Target
+:Scope: input
+:Type: string
+:Default: input=none
+:Required?: yes
+:Introduced: at least 7.0.0, possibly earlier
+
+Description
+-----------
+The target server to connect to.
+
+Input usage
+-----------
+.. _param-omrelp-input-target:
+.. _omrelp.parameter.input.target-usage:
+
+.. code-block:: rsyslog
+
+   action(type="omrelp" target="centralserv")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omrelp`.

--- a/doc/source/reference/parameters/omrelp-template.rst
+++ b/doc/source/reference/parameters/omrelp-template.rst
@@ -1,0 +1,41 @@
+.. _param-omrelp-template:
+.. _omrelp.parameter.input.template:
+
+Template
+========
+
+.. index::
+   single: omrelp; Template
+   single: Template
+
+.. summary-start
+
+Selects the output template used to format RELP messages.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omrelp`.
+
+:Name: Template
+:Scope: input
+:Type: string
+:Default: input=RSYSLOG_ForwardFormat
+:Required?: no
+:Introduced: at least 7.0.0, possibly earlier
+
+Description
+-----------
+Defines the template to be used for the output.
+
+Input usage
+-----------
+.. _param-omrelp-input-template:
+.. _omrelp.parameter.input.template-usage:
+
+.. code-block:: rsyslog
+
+   action(type="omrelp" target="centralserv" template="RSYSLOG_ForwardFormat")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omrelp`.

--- a/doc/source/reference/parameters/omrelp-timeout.rst
+++ b/doc/source/reference/parameters/omrelp-timeout.rst
@@ -1,0 +1,41 @@
+.. _param-omrelp-timeout:
+.. _omrelp.parameter.input.timeout:
+
+Timeout
+=======
+
+.. index::
+   single: omrelp; Timeout
+   single: Timeout
+
+.. summary-start
+
+Sets the RELP session timeout before a connection is considered dead.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omrelp`.
+
+:Name: Timeout
+:Scope: input
+:Type: integer
+:Default: input=90
+:Required?: no
+:Introduced: at least 7.0.0, possibly earlier
+
+Description
+-----------
+Timeout for relp sessions. If set too low, valid sessions may be considered dead and tried to recover.
+
+Input usage
+-----------
+.. _param-omrelp-input-timeout:
+.. _omrelp.parameter.input.timeout-usage:
+
+.. code-block:: rsyslog
+
+   action(type="omrelp" target="centralserv" timeout="120")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omrelp`.

--- a/doc/source/reference/parameters/omrelp-tls-authmode.rst
+++ b/doc/source/reference/parameters/omrelp-tls-authmode.rst
@@ -1,0 +1,45 @@
+.. _param-omrelp-tls-authmode:
+.. _omrelp.parameter.input.tls-authmode:
+
+TLS.AuthMode
+============
+
+.. index::
+   single: omrelp; TLS.AuthMode
+   single: TLS.AuthMode
+
+.. summary-start
+
+Chooses the mutual authentication mode (fingerprint or name) for TLS.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omrelp`.
+
+:Name: TLS.AuthMode
+:Scope: input
+:Type: string
+:Default: input=none
+:Required?: no
+:Introduced: at least 7.0.0, possibly earlier
+
+Description
+-----------
+Sets the mode used for mutual authentication. Supported values are either "*fingerprint*" or "*name*". Fingerprint mode basically is what SSH does. It does not require a full PKI to be present, instead self-signed certs can be used on all peers. Even if a CA certificate is given, the validity of the peer cert is NOT verified against it. Only the certificate fingerprint counts.
+
+In "name" mode, certificate validation happens. Here, the matching is done against the certificate's subjectAltName and, as a fallback, the subject common name. If the certificate contains multiple names, a match on any one of these names is considered good and permits the peer to talk to rsyslog.
+
+The permitted names or fingerprints are configured via `TLS.PermittedPeer`.
+
+Input usage
+-----------
+.. _param-omrelp-input-tls-authmode:
+.. _omrelp.parameter.input.tls-authmode-usage:
+
+.. code-block:: rsyslog
+
+   action(type="omrelp" target="centralserv" tls.authMode="fingerprint")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omrelp`.

--- a/doc/source/reference/parameters/omrelp-tls-cacert.rst
+++ b/doc/source/reference/parameters/omrelp-tls-cacert.rst
@@ -1,0 +1,47 @@
+.. _param-omrelp-tls-cacert:
+.. _omrelp.parameter.input.tls-cacert:
+
+TLS.CaCert
+==========
+
+.. index::
+   single: omrelp; TLS.CaCert
+   single: TLS.CaCert
+
+.. summary-start
+
+Specifies the CA certificate used to verify peer certificates.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omrelp`.
+
+:Name: TLS.CaCert
+:Scope: input
+:Type: string
+:Default: input=none
+:Required?: no
+:Introduced: at least 7.0.0, possibly earlier
+
+Description
+-----------
+The CA certificate that can verify the machine certs.
+
+.. versionadded:: 8.2008.0
+
+   With librelp 1.7.0, you can use chained certificates. If using "openssl" as tls.tlslib, we recommend at least OpenSSL Version 1.1 or higher. Chained certificates will also work with OpenSSL Version 1.0.2, but they will be loaded into the main OpenSSL context object making them available to all librelp instances (omrelp/imrelp) within the same process.
+
+   If this is not desired, you will require to run rsyslog in multiple instances with different omrelp configurations and certificates.
+
+Input usage
+-----------
+.. _param-omrelp-input-tls-cacert:
+.. _omrelp.parameter.input.tls-cacert-usage:
+
+.. code-block:: rsyslog
+
+   action(type="omrelp" target="centralserv" tls.caCert="/path/to/ca.pem")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omrelp`.

--- a/doc/source/reference/parameters/omrelp-tls-compression.rst
+++ b/doc/source/reference/parameters/omrelp-tls-compression.rst
@@ -1,0 +1,41 @@
+.. _param-omrelp-tls-compression:
+.. _omrelp.parameter.input.tls-compression:
+
+TLS.Compression
+===============
+
+.. index::
+   single: omrelp; TLS.Compression
+   single: TLS.Compression
+
+.. summary-start
+
+Controls whether the TLS stream is compressed.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omrelp`.
+
+:Name: TLS.Compression
+:Scope: input
+:Type: boolean
+:Default: input=off
+:Required?: no
+:Introduced: at least 7.0.0, possibly earlier
+
+Description
+-----------
+The controls if the TLS stream should be compressed (zipped). While this increases CPU use, the network bandwidth should be reduced. Note that typical text-based log records usually compress rather well.
+
+Input usage
+-----------
+.. _param-omrelp-input-tls-compression:
+.. _omrelp.parameter.input.tls-compression-usage:
+
+.. code-block:: rsyslog
+
+   action(type="omrelp" target="centralserv" tls.compression="on")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omrelp`.

--- a/doc/source/reference/parameters/omrelp-tls-mycert.rst
+++ b/doc/source/reference/parameters/omrelp-tls-mycert.rst
@@ -1,0 +1,41 @@
+.. _param-omrelp-tls-mycert:
+.. _omrelp.parameter.input.tls-mycert:
+
+TLS.MyCert
+==========
+
+.. index::
+   single: omrelp; TLS.MyCert
+   single: TLS.MyCert
+
+.. summary-start
+
+Provides the path to the machine's public certificate.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omrelp`.
+
+:Name: TLS.MyCert
+:Scope: input
+:Type: string
+:Default: input=none
+:Required?: no
+:Introduced: at least 7.0.0, possibly earlier
+
+Description
+-----------
+The machine public certificate.
+
+Input usage
+-----------
+.. _param-omrelp-input-tls-mycert:
+.. _omrelp.parameter.input.tls-mycert-usage:
+
+.. code-block:: rsyslog
+
+   action(type="omrelp" target="centralserv" tls.myCert="/path/to/cert.pem")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omrelp`.

--- a/doc/source/reference/parameters/omrelp-tls-myprivkey.rst
+++ b/doc/source/reference/parameters/omrelp-tls-myprivkey.rst
@@ -1,0 +1,41 @@
+.. _param-omrelp-tls-myprivkey:
+.. _omrelp.parameter.input.tls-myprivkey:
+
+TLS.MyPrivKey
+=============
+
+.. index::
+   single: omrelp; TLS.MyPrivKey
+   single: TLS.MyPrivKey
+
+.. summary-start
+
+Specifies the path to the machine's private key for TLS.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omrelp`.
+
+:Name: TLS.MyPrivKey
+:Scope: input
+:Type: string
+:Default: input=none
+:Required?: no
+:Introduced: at least 7.0.0, possibly earlier
+
+Description
+-----------
+The machine private key.
+
+Input usage
+-----------
+.. _param-omrelp-input-tls-myprivkey:
+.. _omrelp.parameter.input.tls-myprivkey-usage:
+
+.. code-block:: rsyslog
+
+   action(type="omrelp" target="centralserv" tls.myPrivKey="/path/to/key.pem")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omrelp`.

--- a/doc/source/reference/parameters/omrelp-tls-permittedpeer.rst
+++ b/doc/source/reference/parameters/omrelp-tls-permittedpeer.rst
@@ -1,0 +1,67 @@
+.. _param-omrelp-tls-permittedpeer:
+.. _omrelp.parameter.input.tls-permittedpeer:
+
+TLS.PermittedPeer
+=================
+
+.. index::
+   single: omrelp; TLS.PermittedPeer
+   single: TLS.PermittedPeer
+
+.. summary-start
+
+Restricts which peers may connect based on expected names or fingerprints.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omrelp`.
+
+:Name: TLS.PermittedPeer
+:Scope: input
+:Type: array
+:Default: input=none
+:Required?: no
+:Introduced: at least 7.0.0, possibly earlier
+
+Description
+-----------
+Note: this parameter is mandatory depending on the value of `TLS.AuthMode` but the code does currently not check this.
+
+Peer Places access restrictions on this forwarder. Only peers which have been listed in this parameter may be connected to. This guards against rogue servers and man-in-the-middle attacks. The validation bases on the certificate the remote peer presents.
+
+This contains either remote system names or fingerprints, depending on the value of parameter `TLS.AuthMode`. One or more values may be entered.
+
+When a non-permitted peer is connected to, the refusal is logged together with the given remote peer identify. This is especially useful in *fingerprint* authentication mode: if the administrator knows this was a valid request, he can simply add the fingerprint by copy and paste from the logfile to rsyslog.conf. It must be noted, though, that this situation should usually not happen after initial client setup and administrators should be alert in this case.
+
+Note that usually a single remote peer should be all that is ever needed. Support for multiple peers is primarily included in support of load balancing scenarios. If the connection goes to a specific server, only one specific certificate is ever expected (just like when connecting to a specific ssh server). To specify multiple fingerprints, just enclose them in braces like this:
+
+.. code-block:: rsyslog
+
+   tls.permittedPeer=["SHA1:...1", "SHA1:....2"]
+
+To specify just a single peer, you can either specify the string directly or enclose it in braces.
+
+Note that in *name* authentication mode wildcards are supported. This can be done as follows:
+
+.. code-block:: rsyslog
+
+   tls.permittedPeer="*.example.com"
+
+Of course, there can also be multiple names used, some with and some without wildcards:
+
+.. code-block:: rsyslog
+
+   tls.permittedPeer=["*.example.com", "srv1.example.net", "srv2.example.net"]
+
+Input usage
+-----------
+.. _param-omrelp-input-tls-permittedpeer:
+.. _omrelp.parameter.input.tls-permittedpeer-usage:
+
+.. code-block:: rsyslog
+
+   action(type="omrelp" target="centralserv" tls.permittedPeer="*.example.com")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omrelp`.

--- a/doc/source/reference/parameters/omrelp-tls-prioritystring.rst
+++ b/doc/source/reference/parameters/omrelp-tls-prioritystring.rst
@@ -1,0 +1,41 @@
+.. _param-omrelp-tls-prioritystring:
+.. _omrelp.parameter.input.tls-prioritystring:
+
+TLS.PriorityString
+==================
+
+.. index::
+   single: omrelp; TLS.PriorityString
+   single: TLS.PriorityString
+
+.. summary-start
+
+Passes a custom GnuTLS priority string to control TLS parameters.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omrelp`.
+
+:Name: TLS.PriorityString
+:Scope: input
+:Type: string
+:Default: input=none
+:Required?: no
+:Introduced: at least 7.0.0, possibly earlier
+
+Description
+-----------
+This parameter permits to specify the so-called "priority string" to GnuTLS. This string gives complete control over all crypto parameters, including compression setting. For this reason, when the prioritystring is specified, the "tls.compression" parameter has no effect and is ignored. Full information about how to construct a priority string can be found in the GnuTLS manual. At the time of this writing, this information was contained in `section 6.10 of the GnuTLS manual <http://gnutls.org/manual/html_node/Priority-Strings.html>`__. **Note: this is an expert parameter.** Do not use if you do not exactly know what you are doing.
+
+Input usage
+-----------
+.. _param-omrelp-input-tls-prioritystring:
+.. _omrelp.parameter.input.tls-prioritystring-usage:
+
+.. code-block:: rsyslog
+
+   action(type="omrelp" target="centralserv" tls.priorityString="NORMAL")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omrelp`.

--- a/doc/source/reference/parameters/omrelp-tls-tlscfgcmd.rst
+++ b/doc/source/reference/parameters/omrelp-tls-tlscfgcmd.rst
@@ -1,0 +1,62 @@
+.. _param-omrelp-tls-tlscfgcmd:
+.. _omrelp.parameter.input.tls-tlscfgcmd:
+
+tls.tlscfgcmd
+=============
+
+.. index::
+   single: omrelp; tls.tlscfgcmd
+   single: tls.tlscfgcmd
+
+.. summary-start
+
+Passes OpenSSL configuration commands to librelp when using the OpenSSL TLS backend.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omrelp`.
+
+:Name: tls.tlscfgcmd
+:Scope: input
+:Type: string
+:Default: input=none
+:Required?: no
+:Introduced: 8.2001.0
+
+Description
+-----------
+.. versionadded:: 8.2001.0
+
+The setting can be used if tls.tlslib is set to "openssl" to pass configuration commands to the openssl library. OpenSSL Version 1.0.2 or higher is required for this feature. A list of possible commands and their valid values can be found in the documentation: https://docs.openssl.org/1.0.2/man3/SSL_CONF_cmd/
+
+The setting can be single or multiline, each configuration command is separated by linefeed (\n). Command and value are separated by equal sign (=). Here are a few samples:
+
+Example 1
+---------
+This will allow all protocols except for SSLv2 and SSLv3:
+
+.. code-block:: rsyslog
+
+   tls.tlscfgcmd="Protocol=ALL,-SSLv2,-SSLv3"
+
+Example 2
+---------
+This will allow all protocols except for SSLv2, SSLv3 and TLSv1. It will also set the minimum protocol to TLSv1.2
+
+.. code-block:: rsyslog
+
+   tls.tlscfgcmd="Protocol=ALL,-SSLv2,-SSLv3,-TLSv1
+   MinProtocol=TLSv1.2"
+
+Input usage
+-----------
+.. _param-omrelp-input-tls-tlscfgcmd:
+.. _omrelp.parameter.input.tls-tlscfgcmd-usage:
+
+.. code-block:: rsyslog
+
+   action(type="omrelp" target="centralserv" tls.tlscfgcmd="Protocol=ALL,-SSLv3")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omrelp`.

--- a/doc/source/reference/parameters/omrelp-tls-tlslib.rst
+++ b/doc/source/reference/parameters/omrelp-tls-tlslib.rst
@@ -1,0 +1,49 @@
+.. _param-omrelp-tls-tlslib:
+.. _omrelp.parameter.module.tls-tlslib:
+
+tls.tlslib
+==========
+
+.. index::
+   single: omrelp; tls.tlslib
+   single: tls.tlslib
+
+.. summary-start
+
+Specifies which TLS library librelp uses for RELP operations.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omrelp`.
+
+:Name: tls.tlslib
+:Scope: module
+:Type: string
+:Default: module=none
+:Required?: no
+:Introduced: 8.1903.0
+
+Description
+-----------
+.. versionadded:: 8.1903.0
+
+Permits to specify the TLS library used by librelp. All RELP protocol operations are actually performed by librelp and not rsyslog itself. This value is directly passed down to librelp. Depending on librelp version and build parameters, supported TLS libraries differ (or TLS may not be supported at all). In this case rsyslog emits an error message.
+
+Usually, the following options should be available: "openssl", "gnutls".
+
+Note that "gnutls" is the current default for historic reasons. We actually recommend to use "openssl". It provides better error messages and accepts a wider range of certificate types.
+
+If you have problems with the default setting, we recommend to switch to "openssl".
+
+Module usage
+------------
+.. _param-omrelp-module-tls-tlslib:
+.. _omrelp.parameter.module.tls-tlslib-usage:
+
+.. code-block:: rsyslog
+
+   module(load="omrelp" tls.tlslib="openssl")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omrelp`.

--- a/doc/source/reference/parameters/omrelp-tls.rst
+++ b/doc/source/reference/parameters/omrelp-tls.rst
@@ -1,0 +1,45 @@
+.. _param-omrelp-tls:
+.. _omrelp.parameter.input.tls:
+
+TLS
+===
+
+.. index::
+   single: omrelp; TLS
+   single: TLS
+
+.. summary-start
+
+Enables TLS encryption for the RELP connection.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omrelp`.
+
+:Name: TLS
+:Scope: input
+:Type: boolean
+:Default: input=off
+:Required?: no
+:Introduced: at least 7.0.0, possibly earlier
+
+Description
+-----------
+If set to "on", the RELP connection will be encrypted by TLS, so that the data is protected against observers. Please note that both the client and the server must have set TLS to either "on" or "off". Other combinations lead to unpredictable results.
+
+*Attention when using GnuTLS 2.10.x or older*
+
+Versions older than GnuTLS 2.10.x may cause a crash (Segfault) under certain circumstances. Most likely when an imrelp inputs and an omrelp output is configured. The crash may happen when you are receiving/sending messages at the same time. Upgrade to a newer version like GnuTLS 2.12.21 to solve the problem.
+
+Input usage
+-----------
+.. _param-omrelp-input-tls:
+.. _omrelp.parameter.input.tls-usage:
+
+.. code-block:: rsyslog
+
+   action(type="omrelp" target="centralserv" tls="on")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omrelp`.

--- a/doc/source/reference/parameters/omrelp-windowsize.rst
+++ b/doc/source/reference/parameters/omrelp-windowsize.rst
@@ -1,0 +1,41 @@
+.. _param-omrelp-windowsize:
+.. _omrelp.parameter.input.windowsize:
+
+WindowSize
+==========
+
+.. index::
+   single: omrelp; WindowSize
+   single: WindowSize
+
+.. summary-start
+
+Overrides the RELP client window size used for message transmission.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omrelp`.
+
+:Name: WindowSize
+:Scope: input
+:Type: integer
+:Default: input=0
+:Required?: no
+:Introduced: at least 7.0.0, possibly earlier
+
+Description
+-----------
+This is an **expert parameter**. It permits to override the RELP window size being used by the client. Changing the window size has both an effect on performance as well as potential message duplication in failure case. A larger window size means more performance, but also potentially more duplicated messages - and vice versa. The default 0 means that librelp's default window size is being used, which is considered a compromise between goals reached. For your information: at the time of this writing, the librelp default window size is 128 messages, but this may change at any time. Note that there is no equivalent server parameter, as the client proposes and manages the window size in RELP protocol.
+
+Input usage
+-----------
+.. _param-omrelp-input-windowsize:
+.. _omrelp.parameter.input.windowsize-usage:
+
+.. code-block:: rsyslog
+
+   action(type="omrelp" target="centralserv" windowSize="256")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omrelp`.


### PR DESCRIPTION
## Summary
- split omrelp module and action parameters into individual reference pages with scope-correct anchors and usage blocks
- replace inline omrelp parameter tables with summary list-tables and a hidden toctree, keeping the case-insensitivity note
- preserve TLS-related version notes and examples while aligning casing guidance

## Testing
- Not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937d8600e0883309265abdf789795b7)