### PR TITLE
omruleset: split parameter docs into reference pages; add summary list-tables; fix anchors

### DIFF
--- a/doc/source/configuration/modules/omruleset.rst
+++ b/doc/source/configuration/modules/omruleset.rst
@@ -71,17 +71,18 @@ before using omruleset!**
 
 .. note::
 
-   Parameter names are case-insensitive.
+   Parameter names are case-insensitive; camelCase is recommended for readability.
 
--  **$ActionOmrulesetRulesetName** ruleset-to-submit-to
-   This directive specifies the name of the ruleset that the message
-   provided to omruleset should be submitted to. This ruleset must
-   already have been defined. Note that the directive is automatically
-   reset after each :omruleset: action and there is no default. This is
-   done to prevent accidental loops in ruleset definition, what can
-   happen very quickly. The :omruleset: action will NOT be honored if no
-   ruleset name has been defined. As usual, the ruleset name must be
-   specified in front of the action that it modifies.
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Parameter
+     - Summary
+   * - :ref:`param-omruleset-actionomrulesetrulesetname`
+     - .. include:: ../../reference/parameters/omruleset-actionomrulesetrulesetname.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
 
 
 Examples
@@ -181,4 +182,9 @@ care when nesting rulesets and be sure to test-run your config before
 putting it into production, ensuring you have a sufficiently large probe
 of the traffic run over it. If problems arise, the `rsyslog debug
 log <troubleshoot.html>`_ is your friend.
+
+.. toctree::
+   :hidden:
+
+   ../../reference/parameters/omruleset-actionomrulesetrulesetname
 

--- a/doc/source/configuration/modules/omruleset.rst
+++ b/doc/source/configuration/modules/omruleset.rst
@@ -71,7 +71,8 @@ Input Parameters
 
 .. note::
 
-   Parameter names are case-insensitive; camelCase is recommended for readability.
+   Parameter names are case-insensitive; camelCase is recommended
+   for readability.
 
 .. list-table::
    :widths: 30 70

--- a/doc/source/configuration/modules/omruleset.rst
+++ b/doc/source/configuration/modules/omruleset.rst
@@ -67,7 +67,7 @@ before using omruleset!**
 
 
 Input Parameters
-================
+----------------
 
 .. note::
 
@@ -84,6 +84,20 @@ Input Parameters
      - .. include:: ../../reference/parameters/omruleset-ruleset.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+
+
+Legacy syntax
+~~~~~~~~~~~~~
+
+**$ActionOmrulesetRulesetName** ruleset-to-submit-to
+This directive specifies the name of the ruleset that the message provided
+to omruleset should be submitted to. This ruleset must already have been
+defined. Note that the directive is automatically reset after each
+:omruleset: action and there is no default. This is done to prevent
+accidental loops in ruleset definition, what can happen very quickly. The
+:omruleset: action will NOT be honored if no ruleset name has been defined.
+As usual, the ruleset name must be specified in front of the action that it
+modifies.
 
 
 Examples

--- a/doc/source/configuration/modules/omruleset.rst
+++ b/doc/source/configuration/modules/omruleset.rst
@@ -79,8 +79,8 @@ before using omruleset!**
 
    * - Parameter
      - Summary
-   * - :ref:`param-omruleset-actionomrulesetrulesetname`
-     - .. include:: ../../reference/parameters/omruleset-actionomrulesetrulesetname.rst
+   * - :ref:`param-omruleset-ruleset`
+     - .. include:: ../../reference/parameters/omruleset-ruleset.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
 
@@ -186,5 +186,5 @@ log <troubleshoot.html>`_ is your friend.
 .. toctree::
    :hidden:
 
-   ../../reference/parameters/omruleset-actionomrulesetrulesetname
+   ../../reference/parameters/omruleset-ruleset
 

--- a/doc/source/configuration/modules/omruleset.rst
+++ b/doc/source/configuration/modules/omruleset.rst
@@ -66,8 +66,8 @@ before using omruleset!**
    endless loops - the rsyslog engine does not detect these
 
 
-|FmtObsoleteName| directives
-============================
+Input Parameters
+================
 
 .. note::
 

--- a/doc/source/reference/parameters/omruleset-actionomrulesetrulesetname.rst
+++ b/doc/source/reference/parameters/omruleset-actionomrulesetrulesetname.rst
@@ -1,0 +1,53 @@
+.. _param-omruleset-actionomrulesetrulesetname:
+.. _omruleset.parameter.module.actionomrulesetrulesetname:
+
+Ruleset
+=======
+
+.. index::
+   single: omruleset; Ruleset
+   single: Ruleset
+
+.. summary-start
+
+Specifies the target ruleset that omruleset should submit messages to.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omruleset`.
+
+:Name: Ruleset
+:Scope: module
+:Type: string
+:Default: module=no default
+:Required?: yes
+:Introduced: 5.3.4
+
+Description
+-----------
+This parameter specifies the name of the ruleset that the message provided to omruleset should be submitted to. The ruleset must already exist. The directive is automatically reset after each :omruleset: action and there is no default. This behavior helps prevent accidental loops in ruleset definition. The :omruleset: action is ignored if no ruleset name has been defined. As usual, the ruleset name must be specified in front of the action that it modifies.
+
+Module usage
+------------
+.. _param-omruleset-module-actionomrulesetrulesetname:
+.. _omruleset.parameter.module.actionomrulesetrulesetname-usage:
+
+.. code-block:: rsyslog
+
+   module(load="omruleset")
+   action(type="omruleset" ruleset="CommonAction")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _omruleset.parameter.legacy.actionomrulesetrulesetname:
+- $ActionOmrulesetRulesetName — maps to Ruleset (status: legacy)
+
+.. index::
+   single: omruleset; $ActionOmrulesetRulesetName
+   single: $ActionOmrulesetRulesetName
+
+See also
+--------
+See also :doc:`../../configuration/modules/omruleset`.

--- a/doc/source/reference/parameters/omruleset-ruleset.rst
+++ b/doc/source/reference/parameters/omruleset-ruleset.rst
@@ -29,7 +29,6 @@ This parameter specifies the name of the ruleset that the message provided to om
 
 Module usage
 ------------
-.. _param-omruleset-module-ruleset:
 .. _omruleset.parameter.module.ruleset-usage:
 
 .. code-block:: rsyslog

--- a/doc/source/reference/parameters/omruleset-ruleset.rst
+++ b/doc/source/reference/parameters/omruleset-ruleset.rst
@@ -19,7 +19,7 @@ This parameter applies to :doc:`../../configuration/modules/omruleset`.
 :Name: Ruleset
 :Scope: module
 :Type: string
-:Default: module=no default
+:Default: No default
 :Required?: yes
 :Introduced: 5.3.4
 

--- a/doc/source/reference/parameters/omruleset-ruleset.rst
+++ b/doc/source/reference/parameters/omruleset-ruleset.rst
@@ -29,7 +29,7 @@ This parameter specifies the name of the ruleset that the message provided to om
 
 Input usage
 -----------
-.. _param-omruleset-input-ruleset:
+.. _param-omruleset-ruleset-usage:
 .. _omruleset.parameter.input.ruleset-usage:
 
 .. code-block:: rsyslog

--- a/doc/source/reference/parameters/omruleset-ruleset.rst
+++ b/doc/source/reference/parameters/omruleset-ruleset.rst
@@ -1,5 +1,5 @@
-.. _param-omruleset-actionomrulesetrulesetname:
-.. _omruleset.parameter.module.actionomrulesetrulesetname:
+.. _param-omruleset-ruleset:
+.. _omruleset.parameter.module.ruleset:
 
 Ruleset
 =======
@@ -29,8 +29,8 @@ This parameter specifies the name of the ruleset that the message provided to om
 
 Module usage
 ------------
-.. _param-omruleset-module-actionomrulesetrulesetname:
-.. _omruleset.parameter.module.actionomrulesetrulesetname-usage:
+.. _param-omruleset-module-ruleset:
+.. _omruleset.parameter.module.ruleset-usage:
 
 .. code-block:: rsyslog
 

--- a/doc/source/reference/parameters/omruleset-ruleset.rst
+++ b/doc/source/reference/parameters/omruleset-ruleset.rst
@@ -1,5 +1,5 @@
 .. _param-omruleset-ruleset:
-.. _omruleset.parameter.module.ruleset:
+.. _omruleset.parameter.input.ruleset:
 
 Ruleset
 =======
@@ -17,7 +17,7 @@ Specifies the target ruleset that omruleset should submit messages to.
 This parameter applies to :doc:`../../configuration/modules/omruleset`.
 
 :Name: Ruleset
-:Scope: module
+:Scope: input
 :Type: string
 :Default: No default
 :Required?: yes
@@ -27,9 +27,10 @@ Description
 -----------
 This parameter specifies the name of the ruleset that the message provided to omruleset should be submitted to. The ruleset must already exist. The directive is automatically reset after each :omruleset: action and there is no default. This behavior helps prevent accidental loops in ruleset definition. The :omruleset: action is ignored if no ruleset name has been defined. As usual, the ruleset name must be specified in front of the action that it modifies.
 
-Module usage
-------------
-.. _omruleset.parameter.module.ruleset-usage:
+Input usage
+-----------
+.. _param-omruleset-input-ruleset:
+.. _omruleset.parameter.input.ruleset-usage:
 
 .. code-block:: rsyslog
 

--- a/doc/source/reference/parameters/omruleset-ruleset.rst
+++ b/doc/source/reference/parameters/omruleset-ruleset.rst
@@ -25,7 +25,7 @@ This parameter applies to :doc:`../../configuration/modules/omruleset`.
 
 Description
 -----------
-This parameter specifies the name of the ruleset that the message provided to omruleset should be submitted to. The ruleset must already exist. The directive is automatically reset after each :omruleset: action and there is no default. This behavior helps prevent accidental loops in ruleset definition. The :omruleset: action is ignored if no ruleset name has been defined. As usual, the ruleset name must be specified in front of the action that it modifies.
+This parameter specifies the name of the ruleset that the message provided to omruleset should be submitted to. The target ruleset must already be defined. This parameter is required for each ``omruleset`` action, which helps prevent accidental misconfiguration and potential processing loops.
 
 Input usage
 -----------
@@ -38,7 +38,7 @@ Input usage
    action(type="omruleset" ruleset="CommonAction")
 
 Legacy names (for reference)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------
 Historic names/directives for compatibility. Do not use in new configs.
 
 .. _omruleset.parameter.legacy.actionomrulesetrulesetname:

--- a/doc/source/reference/parameters/omruleset-ruleset.rst
+++ b/doc/source/reference/parameters/omruleset-ruleset.rst
@@ -25,7 +25,10 @@ This parameter applies to :doc:`../../configuration/modules/omruleset`.
 
 Description
 -----------
-This parameter specifies the name of the ruleset that the message provided to omruleset should be submitted to. The target ruleset must already be defined. This parameter is required for each ``omruleset`` action, which helps prevent accidental misconfiguration and potential processing loops.
+This parameter specifies the name of the ruleset that the message provided
+to omruleset should be submitted to. The target ruleset must already be
+defined. This parameter is required for each ``omruleset`` action, which
+helps prevent accidental misconfiguration and potential processing loops.
 
 Input usage
 -----------


### PR DESCRIPTION
## Summary
- move the omruleset Ruleset parameter to a dedicated reference page with module-scoped anchors and legacy alias
- replace the inline obsolete directive description with a summary list-table and add a hidden toctree entry

## Testing
- Not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937e5d3d30883308dc2faab94732d61)