### PR TITLE
omsnmp: align parameter heading with module scope

### DIFF
--- a/doc/source/configuration/modules/omsnmp.rst
+++ b/doc/source/configuration/modules/omsnmp.rst
@@ -27,7 +27,7 @@ Configuration Parameters
 
    Parameter names are case-insensitive; camelCase is recommended for readability.
 
-Action Parameters
+Module Parameters
 -----------------
 
 .. list-table::


### PR DESCRIPTION
## Summary
- rename the Action Parameters heading to Module Parameters so the omsnmp module page reflects the parameter scope naming
- retain the existing parameter list-table and case-sensitivity note for the omsnmp configuration section

## Testing
- not run (documentation change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69398c555e908330bf68d00d9dfab2e4)